### PR TITLE
feat(connectivity): check whether pods are in same mesh

### DIFF
--- a/cmd/connectivity_pod_to_pod.go
+++ b/cmd/connectivity_pod_to_pod.go
@@ -27,8 +27,8 @@ Example:
 
 type connectivityPodToPodCmd struct {
 	out             io.Writer
-	fromPod         string
-	toPod           string
+	srcPod          string
+	destPod         string
 	clientSet       kubernetes.Interface
 	smiAccessClient smiAccessClient.Interface
 	// meshConfigClient osmConfigClient.Interface
@@ -46,8 +46,8 @@ func newConnectivityPodToPodCmd(config *action.Configuration, in io.Reader, out 
 		Long:  connectivityPodToPodDesc,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			podToPodCmd.fromPod = args[0]
-			podToPodCmd.toPod = args[1]
+			podToPodCmd.srcPod = args[0]
+			podToPodCmd.destPod = args[1]
 
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
@@ -56,11 +56,11 @@ func newConnectivityPodToPodCmd(config *action.Configuration, in io.Reader, out 
 
 			podToPodCmd.restConfig = config
 
-			clientset, err := kubernetes.NewForConfig(config)
+			clientSet, err := kubernetes.NewForConfig(config)
 			if err != nil {
 				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
-			podToPodCmd.clientSet = clientset
+			podToPodCmd.clientSet = clientSet
 
 			accessClient, err := smiAccessClient.NewForConfig(config)
 			if err != nil {
@@ -82,16 +82,16 @@ func newConnectivityPodToPodCmd(config *action.Configuration, in io.Reader, out 
 }
 
 func (podToPodCmd *connectivityPodToPodCmd) run() error {
-	fromPod, err := kubernetesHelper.PodFromString(podToPodCmd.fromPod)
+	srcPod, err := kubernetesHelper.PodFromString(podToPodCmd.srcPod)
 	if err != nil {
 		return errors.New("invalid SOURCE_POD")
 	}
 
-	toPod, err := kubernetesHelper.PodFromString(podToPodCmd.toPod)
+	destPod, err := kubernetesHelper.PodFromString(podToPodCmd.destPod)
 	if err != nil {
 		return errors.New("invalid DESTINATION_POD")
 	}
 
-	connectivity.PodToPod(fromPod, toPod)
+	connectivity.PodToPod(srcPod, destPod, podToPodCmd.clientSet)
 	return nil
 }

--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -17,8 +17,12 @@ func PodToPod(srcPod *v1.Pod, destPod *v1.Pod, clientSet kubernetes.Interface) c
 
 	// TODO: actually test connectivity
 	srcPodLabels := srcPod.ObjectMeta.GetLabels()
-	for key,val := range srcPodLabels {
-		fmt.Printf("key: %s, val: %s\n", key,val)
+	for label,val := range srcPodLabels {
+		fmt.Printf("label: %s, val: %s\n", label,val)
+	}
+	srcPodAnnotations := srcPod.ObjectMeta.GetAnnotations()
+	for annotation,val := range srcPodAnnotations {
+		fmt.Printf("annotation: %s, val: %s\n", annotation,val)
 	}
 	inSameMesh, err := arePodsInSameMesh(srcPod, destPod, clientSet)
 	if err != nil {

--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -1,17 +1,30 @@
 package connectivity
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
 )
 
 // PodToPod tests the connectivity between a source and destination pods.
-func PodToPod(fromPod *v1.Pod, toPod *v1.Pod) common.Result {
-	log.Info().Msgf("Testing connectivity from %s/%s to %s/%s", fromPod.Namespace, fromPod.Name, toPod.Namespace, toPod.Name)
+func PodToPod(srcPod *v1.Pod, destPod *v1.Pod, clientSet kubernetes.Interface) common.Result {
+	log.Info().Msgf("Testing connectivity from %s/%s to %s/%s", srcPod.Namespace, srcPod.Name, destPod.Namespace, destPod.Name)
 
 	// TODO: actually test connectivity
+	srcPodLabels := srcPod.ObjectMeta.GetLabels()
+	for key,val := range srcPodLabels {
+		fmt.Printf("key: %s, val: %s\n", key,val)
+	}
+	inSameMesh, err := arePodsInSameMesh(srcPod, destPod, clientSet)
+	if err != nil {
+		log.Err(err).Msg("Error getting list of Pods")
+	}
+	fmt.Printf("Pods are in same mesh: %t\n", inSameMesh)
 
 	return common.Result{
 		SMIPolicy: common.SMIPolicy{
@@ -21,4 +34,22 @@ func PodToPod(fromPod *v1.Pod, toPod *v1.Pod) common.Result {
 		},
 		Successful: false,
 	}
+}
+
+func arePodsInSameMesh(srcPod *v1.Pod, destPod *v1.Pod, clientSet kubernetes.Interface) (bool, error) {
+	srcPodNamespace, err := clientSet.CoreV1().Namespaces().Get(context.Background(), srcPod.ObjectMeta.GetNamespace(), v12.GetOptions{})
+	if err != nil {
+		log.Err(err).Msg("Error getting source pod's namespace")
+		return false, errors.New("error getting namespace")
+	}
+	destPodNamespace, err := clientSet.CoreV1().Namespaces().Get(context.Background(), destPod.ObjectMeta.GetNamespace(), v12.GetOptions{})
+	if err != nil {
+		log.Err(err).Msg("Error getting destination pod's namespace")
+		return false, errors.New("error getting namespace")
+	}
+	srcPodMeshName := srcPodNamespace.ObjectMeta.GetLabels()["openservicemesh.io/monitored-by"]
+	if destPodNamespace.ObjectMeta.GetLabels()["openservicemesh.io/monitored-by"] == srcPodMeshName {
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
* implements arePodsInSameMesh to check if pod namespaces are monitored by the same meshName
* demonstrates how to get labels and annotations for pod (for now just prints these for the srcPod)
* Changes toPod and fromPod to dest and src pod. These names were getting unwieldy
