### PR TITLE
Adding a mapping from OSM Controller version to supported SMI TrafficTarget, TrafficSplit, HTTPRouteGrup versions

### DIFF
--- a/pkg/osm/smi.go
+++ b/pkg/osm/smi.go
@@ -23,3 +23,45 @@ var SupportedTrafficTarget = map[ControllerVersion][]TrafficTargetVersion{
 		"v1alpha3",
 	},
 }
+
+// SupportedTrafficSplit is the mapping of OSM Controller version to supported SMI TrafficSplit version.
+var SupportedTrafficSplit = map[ControllerVersion][]TrafficSplitVersion{
+	"v0.5": {
+		"v1alpha2",
+	},
+	"v0.6": {
+		"v1alpha2",
+	},
+	"v0.7": {
+
+		"v1alpha2",
+	},
+	"v0.8": {
+
+		"v1alpha2",
+	},
+	"v0.9": {
+
+		"v1alpha2",
+	},
+}
+
+// SupportedHTTPRouteVersion is a mapping of OSM Controller version to supported HTTP Route Group version.
+var SupportedHTTPRouteVersion = map[ControllerVersion][]HTTPRouteVersion{
+	"v0.5": {
+		"v1alpha3",
+	},
+	"v0.6": {
+		"v1alpha3",
+	},
+	"v0.7": {
+
+		"v1alpha4",
+	},
+	"v0.8": {
+		"v1alpha4",
+	},
+	"v0.9": {
+		"v1alpha4",
+	},
+}

--- a/pkg/osm/smi.go
+++ b/pkg/osm/smi.go
@@ -1,0 +1,25 @@
+package osm
+
+// SupportedTrafficTarget is a map of OSM Controller Version to supported
+var SupportedTrafficTarget = map[ControllerVersion][]TrafficTargetVersion{
+	"v0.5": {
+		// Source: https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L8
+		"v1alpha2",
+	},
+	"v0.6": {
+		// Source: https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L8
+		"v1alpha2",
+	},
+	"v0.7": {
+		// Source: https://github.com/openservicemesh/osm/blob/release-v0.7/pkg/smi/client.go#L8
+		"v1alpha3",
+	},
+	"v0.8": {
+		// Source: https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/smi/client.go#L8
+		"v1alpha3",
+	},
+	"v0.9": {
+		// Source: https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/smi/client.go#L10
+		"v1alpha3",
+	},
+}

--- a/pkg/osm/types.go
+++ b/pkg/osm/types.go
@@ -5,3 +5,12 @@ type ControllerVersion string
 
 // IngressVersion is a string type alias for the Ingress version supported.
 type IngressVersion string
+
+// TrafficTargetVersion is a string type alias for the SMI TrafficTarget version supported.
+type TrafficTargetVersion string
+
+// TrafficSplitVersion is a string type alias for the SMI TrafficSplit version supported.
+type TrafficSplitVersion string
+
+// HTTPRouteVersion is a string type alias for the SMI HTTPRoute version supported.
+type HTTPRouteVersion string


### PR DESCRIPTION
This PR adds a mapping from OSM Controller version to supported TrafficTarget, TrafficSplit, HTTPRouteGrup versions.

The PR is stacked on https://github.com/openservicemesh/osm-health/pull/13

---

A script that is helpful to extract the SMI versions:
```bash
for x in $(seq 5 9); do git checkout "upstream/release-v0.${x}"; echo "\n----\nv0.$x"; grep -Iir 'github.com/servicemeshinterface/smi-sdk-go/pkg/apis' $(find . -type f -name '*.go' | grep -v _test.go) | awk -F: '{print $2}' | sort | uniq; done; git checkout main
```