### PR TITLE
Check whether source Envoy is configured with at least one destination endpoint

### DIFF
--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -51,6 +51,12 @@ func PodToPod(fromPod *v1.Pod, toPod *v1.Pod) common.Result {
 		pod.HasExpectedEnvoyImage(toPod),
 		pod.HasProxyUUIDLabel(toPod),
 
+		// The source Envoy must have at least one endpoint for the destination Envoy.
+		envoy.HasDestinationEndpoints(srcConfigGetter),
+
+		// Check whether the source Pod has on endpoint, which matches the destination Pod.
+		envoy.HasSpecificEndpoint(srcConfigGetter, toPod),
+
 		// Source Envoy must have Outbound listener
 		envoy.HasOutboundListener(srcConfigGetter, osmVersion),
 

--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -54,7 +54,7 @@ func PodToPod(fromPod *v1.Pod, toPod *v1.Pod) common.Result {
 		// The source Envoy must have at least one endpoint for the destination Envoy.
 		envoy.HasDestinationEndpoints(srcConfigGetter),
 
-		// Check whether the source Pod has on endpoint, which matches the destination Pod.
+		// Check whether the source Pod has an endpoint that matches the destination Pod.
 		envoy.HasSpecificEndpoint(srcConfigGetter, toPod),
 
 		// Source Envoy must have Outbound listener

--- a/pkg/envoy/eds.go
+++ b/pkg/envoy/eds.go
@@ -11,16 +11,16 @@ import (
 )
 
 // Verify interface compliance
-var _ common.Runnable = (*HasDestinationEndpointsCheck)(nil)
+var _ common.Runnable = (*DestinationEndpointChecker)(nil)
 
-// HasDestinationEndpointsCheck implements common.Runnable
-type HasDestinationEndpointsCheck struct {
+// DestinationEndpointChecker implements common.Runnable
+type DestinationEndpointChecker struct {
 	*v1.Pod
 	ConfigGetter
 }
 
 // Run implements common.Runnable
-func (l HasDestinationEndpointsCheck) Run() error {
+func (l DestinationEndpointChecker) Run() error {
 	if l.ConfigGetter == nil {
 		log.Error().Msg("Incorrectly initialized ConfigGetter")
 		return ErrIncorrectlyInitializedConfigGetter
@@ -72,7 +72,7 @@ func (l HasDestinationEndpointsCheck) Run() error {
 }
 
 // Info implements common.Runnable
-func (l HasDestinationEndpointsCheck) Info() string {
+func (l DestinationEndpointChecker) Info() string {
 	txt := "at least one destination"
 	if l.Pod != nil {
 		txt = fmt.Sprintf("%s as a destination", l.Status.PodIP)
@@ -83,14 +83,14 @@ func (l HasDestinationEndpointsCheck) Info() string {
 
 // HasDestinationEndpoints creates a new common.Runnable, which checks whether the given Pod has an Envoy with properly configured listener for the local payload.
 func HasDestinationEndpoints(configGetter ConfigGetter) common.Runnable {
-	return HasDestinationEndpointsCheck{
+	return DestinationEndpointChecker{
 		ConfigGetter: configGetter,
 	}
 }
 
 // HasSpecificEndpoint creates a new common.Runnable, which checks whether the given Pod has an Envoy with properly configured listener for the local payload.
 func HasSpecificEndpoint(configGetter ConfigGetter, pod *v1.Pod) common.Runnable {
-	return HasDestinationEndpointsCheck{
+	return DestinationEndpointChecker{
 		ConfigGetter: configGetter,
 		Pod:          pod,
 	}

--- a/pkg/envoy/eds.go
+++ b/pkg/envoy/eds.go
@@ -30,10 +30,6 @@ func (l DestinationEndpointChecker) Run() error {
 		return err
 	}
 
-	if envoyConfig == nil {
-		return ErrEnvoyConfigEmpty
-	}
-
 	if envoyConfig == nil || envoyConfig.Listeners.DynamicListeners == nil {
 		return ErrEnvoyConfigEmpty
 	}

--- a/pkg/envoy/eds.go
+++ b/pkg/envoy/eds.go
@@ -1,0 +1,97 @@
+package envoy
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+
+	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+
+	"github.com/openservicemesh/osm-health/pkg/common"
+)
+
+// Verify interface compliance
+var _ common.Runnable = (*HasDestinationEndpointsCheck)(nil)
+
+// HasDestinationEndpointsCheck implements common.Runnable
+type HasDestinationEndpointsCheck struct {
+	*v1.Pod
+	ConfigGetter
+}
+
+// Run implements common.Runnable
+func (l HasDestinationEndpointsCheck) Run() error {
+	if l.ConfigGetter == nil {
+		log.Error().Msg("Incorrectly initialized ConfigGetter")
+		return ErrIncorrectlyInitializedConfigGetter
+	}
+	envoyConfig, err := l.ConfigGetter.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if envoyConfig == nil {
+		return ErrEnvoyConfigEmpty
+	}
+
+	if envoyConfig == nil || envoyConfig.Listeners.DynamicListeners == nil {
+		return ErrEnvoyConfigEmpty
+	}
+
+	if len(envoyConfig.Endpoints.GetDynamicEndpointConfigs()) <= 0 {
+		log.Error().Msgf("must have at least one destination endpoint: %+v", envoyConfig.Endpoints.GetDynamicEndpointConfigs())
+		return ErrNoDestinationEndpoints
+	}
+
+	var cla envoy_config_endpoint_v3.ClusterLoadAssignment
+	if err = envoyConfig.Endpoints.GetDynamicEndpointConfigs()[0].GetEndpointConfig().UnmarshalTo(&cla); err != nil {
+		return ErrUnmarshalingClusterLoadAssigment
+	}
+
+	if len(cla.Endpoints) <= 0 || len(cla.Endpoints[0].LbEndpoints) <= 0 {
+		log.Error().Msg("must have at least one destination endpoint")
+		return ErrNoDestinationEndpoints
+	}
+
+	// If Pod was defined -- check if this pod IP is in the list of endpoints.
+	if l.Pod != nil {
+		foundIt := false
+		// Check for a specific Pod.
+		for _, ept := range cla.Endpoints[0].LbEndpoints {
+			if ept.GetEndpoint().Address.GetSocketAddress().Address == l.Status.PodIP {
+				foundIt = true
+				break
+			}
+		}
+		if !foundIt {
+			return ErrEndpointNotFound
+		}
+	}
+
+	return nil
+}
+
+// Info implements common.Runnable
+func (l HasDestinationEndpointsCheck) Info() string {
+	txt := "at least one destination"
+	if l.Pod != nil {
+		txt = fmt.Sprintf("%s as a destination", l.Status.PodIP)
+	}
+
+	return fmt.Sprintf("Checking whether %s is configured with %s endpoint", l.ConfigGetter.GetObjectName(), txt)
+}
+
+// HasDestinationEndpoints creates a new common.Runnable, which checks whether the given Pod has an Envoy with properly configured listener for the local payload.
+func HasDestinationEndpoints(configGetter ConfigGetter) common.Runnable {
+	return HasDestinationEndpointsCheck{
+		ConfigGetter: configGetter,
+	}
+}
+
+// HasSpecificEndpoint creates a new common.Runnable, which checks whether the given Pod has an Envoy with properly configured listener for the local payload.
+func HasSpecificEndpoint(configGetter ConfigGetter, pod *v1.Pod) common.Runnable {
+	return HasDestinationEndpointsCheck{
+		ConfigGetter: configGetter,
+		Pod:          pod,
+	}
+}

--- a/pkg/envoy/errors.go
+++ b/pkg/envoy/errors.go
@@ -14,4 +14,13 @@ var (
 
 	// ErrIncorrectlyInitializedConfigGetter is an error
 	ErrIncorrectlyInitializedConfigGetter = errors.New("incorrectly initialized config getter")
+
+	// ErrNoDestinationEndpoints is an error
+	ErrNoDestinationEndpoints = errors.New("no destination endpoints")
+
+	// ErrUnmarshalingClusterLoadAssigment is an error
+	ErrUnmarshalingClusterLoadAssigment = errors.New("error unmarshaling envoy cluster load assigment")
+
+	// ErrEndpointNotFound is an error
+	ErrEndpointNotFound = errors.New("endpoint not found")
 )

--- a/pkg/envoy/errors.go
+++ b/pkg/envoy/errors.go
@@ -3,24 +3,24 @@ package envoy
 import "errors"
 
 var (
-	// ErrEnvoyListenerMissing is an error
+	// ErrEnvoyListenerMissing is an error returned when an Envoy does not have a required listener.
 	ErrEnvoyListenerMissing = errors.New("envoy listener missing")
 
-	// ErrEnvoyConfigEmpty is an error
+	// ErrEnvoyConfigEmpty is an error returned when an Envoy config is completely missing.
 	ErrEnvoyConfigEmpty = errors.New("envoy config is empty")
 
-	// ErrOSMControllerVersionUnrecognized is an error
+	// ErrOSMControllerVersionUnrecognized is an error returned when the supplied OSM Controller version is not recognized.
 	ErrOSMControllerVersionUnrecognized = errors.New("osm controller version not recognized")
 
-	// ErrIncorrectlyInitializedConfigGetter is an error
+	// ErrIncorrectlyInitializedConfigGetter is an error returned when the ConfigGetter struct is not correctly initialized.
 	ErrIncorrectlyInitializedConfigGetter = errors.New("incorrectly initialized config getter")
 
-	// ErrNoDestinationEndpoints is an error
+	// ErrNoDestinationEndpoints is an error returned when an Envoy has no destination endpoints.
 	ErrNoDestinationEndpoints = errors.New("no destination endpoints")
 
-	// ErrUnmarshalingClusterLoadAssigment is an error
+	// ErrUnmarshalingClusterLoadAssigment is an error returned when the unmarshaling of the Envoy ClusterLoadAssignment struct fails.
 	ErrUnmarshalingClusterLoadAssigment = errors.New("error unmarshaling envoy cluster load assigment")
 
-	// ErrEndpointNotFound is an error
+	// ErrEndpointNotFound is an error returned when a specific endpoint is not found in Envoy EDS config.
 	ErrEndpointNotFound = errors.New("endpoint not found")
 )


### PR DESCRIPTION
This PR adds a check - whether the source Envoy has at least one of the Destination endpoints.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>