### PR TITLE
check(*): Include error string when printing check outcomes

### DIFF
--- a/pkg/common/printer.go
+++ b/pkg/common/printer.go
@@ -10,7 +10,7 @@ func Print(outcomes ...Outcome) {
 		foundIssues = foundIssues && issue.Error != nil
 		errString := "OK"
 		if issue.Error != nil {
-			errString = "FAIL"
+			errString = fmt.Sprintf("FAIL: %s", issue.Error.Error())
 			issuesCount = issuesCount + 1
 		}
 		fmt.Printf("%d  %s  -- %s\n", idx+1, issue.RunnableInfo, errString)


### PR DESCRIPTION
check(*): Include error string when printing check outcomes

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>