### PR TITLE
Adding Suggestion() and FixIt() to common.Runnable interface

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -15,10 +15,19 @@ type SMIPolicy struct {
 	// TODO: include actual SMI policy
 }
 
-// Runnable is a type of generic function that can be executed and it will return pass/fail on a given check.
+// Runnable is a type of generic function that can be executed; it returns pass/fail on a given check.
 type Runnable interface {
+	// Run executes a check.
 	Run() error
+
+	// Info returns human-readable information on what check is being executed.
 	Info() string
+
+	// Suggestion returns a human-readable suggestion on how to fix the issue.
+	Suggestion() string
+
+	// FixIt attempts to fix the issue at hand.
+	FixIt() error
 }
 
 // MeshName is the type for the name of a mesh.

--- a/pkg/envoy/eds.go
+++ b/pkg/envoy/eds.go
@@ -67,6 +67,16 @@ func (l DestinationEndpointChecker) Run() error {
 	return nil
 }
 
+// Suggestion implements common.Runnable
+func (l DestinationEndpointChecker) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (l DestinationEndpointChecker) FixIt() error {
+	panic("implement me")
+}
+
 // Info implements common.Runnable
 func (l DestinationEndpointChecker) Info() string {
 	txt := "at least one destination"
@@ -78,14 +88,14 @@ func (l DestinationEndpointChecker) Info() string {
 }
 
 // HasDestinationEndpoints creates a new common.Runnable, which checks whether the given Pod has an Envoy with properly configured listener for the local payload.
-func HasDestinationEndpoints(configGetter ConfigGetter) common.Runnable {
+func HasDestinationEndpoints(configGetter ConfigGetter) DestinationEndpointChecker {
 	return DestinationEndpointChecker{
 		ConfigGetter: configGetter,
 	}
 }
 
 // HasSpecificEndpoint creates a new common.Runnable, which checks whether the given Pod has an Envoy with properly configured listener for the local payload.
-func HasSpecificEndpoint(configGetter ConfigGetter, pod *v1.Pod) common.Runnable {
+func HasSpecificEndpoint(configGetter ConfigGetter, pod *v1.Pod) DestinationEndpointChecker {
 	return DestinationEndpointChecker{
 		ConfigGetter: configGetter,
 		Pod:          pod,

--- a/pkg/envoy/envoy_container_logs.go
+++ b/pkg/envoy/envoy_container_logs.go
@@ -75,3 +75,13 @@ func (check NoBadEnvoyLogsCheck) Run() error {
 
 	return nil
 }
+
+// Suggestion implements common.Runnable.
+func (check NoBadEnvoyLogsCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable.
+func (check NoBadEnvoyLogsCheck) FixIt() error {
+	panic("implement me")
+}

--- a/pkg/envoy/lds.go
+++ b/pkg/envoy/lds.go
@@ -56,13 +56,23 @@ func (l HasListenerCheck) Run() error {
 	return nil
 }
 
+// Suggestion implements common.Runnable
+func (l HasListenerCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (l HasListenerCheck) FixIt() error {
+	panic("implement me")
+}
+
 // Info implements common.Runnable
 func (l HasListenerCheck) Info() string {
 	return fmt.Sprintf("Checking whether %s is configured with correct %s Envoy listener", l.ConfigGetter.GetObjectName(), l.listenerType)
 }
 
 // HasOutboundListener creates a new common.Runnable, which checks whether the given Pod has an Envoy with properly configured listener.
-func HasOutboundListener(configGetter ConfigGetter, osmVersion osm.ControllerVersion) common.Runnable {
+func HasOutboundListener(configGetter ConfigGetter, osmVersion osm.ControllerVersion) HasListenerCheck {
 	return HasListenerCheck{
 		ConfigGetter:      configGetter,
 		ControllerVersion: osmVersion,
@@ -73,7 +83,7 @@ func HasOutboundListener(configGetter ConfigGetter, osmVersion osm.ControllerVer
 }
 
 // HasInboundListener creates a new common.Runnable, which checks whether the given Pod has an Envoy with properly configured listener.
-func HasInboundListener(configGetter ConfigGetter, osmVersion osm.ControllerVersion) common.Runnable {
+func HasInboundListener(configGetter ConfigGetter, osmVersion osm.ControllerVersion) HasListenerCheck {
 	return HasListenerCheck{
 		ConfigGetter:      configGetter,
 		ControllerVersion: osmVersion,

--- a/pkg/kubernetes/namespace/injected.go
+++ b/pkg/kubernetes/namespace/injected.go
@@ -20,6 +20,16 @@ type SidecarInjectionCheck struct {
 	namespace string
 }
 
+// Suggestion implements common.Runnable
+func (check SidecarInjectionCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (check SidecarInjectionCheck) FixIt() error {
+	panic("implement me")
+}
+
 // IsInjectEnabled checks whether a namespace is enabled for sidecar injection.
 func IsInjectEnabled(client kubernetes.Interface, namespace string) SidecarInjectionCheck {
 	return SidecarInjectionCheck{

--- a/pkg/kubernetes/namespace/monitored.go
+++ b/pkg/kubernetes/namespace/monitored.go
@@ -49,3 +49,13 @@ func (check MonitoredCheck) Run() error {
 
 	return nil
 }
+
+// Suggestion implements common.Runnable
+func (check MonitoredCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (check MonitoredCheck) FixIt() error {
+	panic("implement me")
+}

--- a/pkg/kubernetes/pod/containers.go
+++ b/pkg/kubernetes/pod/containers.go
@@ -9,13 +9,16 @@ import (
 	"github.com/openservicemesh/osm-health/pkg/kuberneteshelper"
 )
 
+// Verify interface compliance
+var _ common.Runnable = (*EnvoySidecarImageCheck)(nil)
+
 // EnvoySidecarImageCheck implements common.Runnable
 type EnvoySidecarImageCheck struct {
 	pod *v1.Pod
 }
 
 // HasExpectedEnvoyImage checks whether a pod has a sidecar with the envoy image specified in the meshconfig
-func HasExpectedEnvoyImage(pod *v1.Pod) common.Runnable {
+func HasExpectedEnvoyImage(pod *v1.Pod) EnvoySidecarImageCheck {
 	return EnvoySidecarImageCheck{
 		pod: pod,
 	}
@@ -38,6 +41,19 @@ func (check EnvoySidecarImageCheck) Run() error {
 	return ErrExpectedEnvoyImageMissing
 }
 
+// Suggestion implements common.Runnable
+func (check EnvoySidecarImageCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (check EnvoySidecarImageCheck) FixIt() error {
+	panic("implement me")
+}
+
+// Verify interface compliance
+var _ common.Runnable = (*MinNumContainersCheck)(nil)
+
 // MinNumContainersCheck implements common.Runnable
 type MinNumContainersCheck struct {
 	pod    *v1.Pod
@@ -46,7 +62,7 @@ type MinNumContainersCheck struct {
 
 // HasMinExpectedContainers checks whether a pod has at least the min number of containers expected
 // This currently corresponds to an app container, osm init container and envoy proxy sidecar
-func HasMinExpectedContainers(pod *v1.Pod, num int) common.Runnable {
+func HasMinExpectedContainers(pod *v1.Pod, num int) MinNumContainersCheck {
 	return MinNumContainersCheck{
 		pod:    pod,
 		minNum: num,
@@ -64,4 +80,14 @@ func (check MinNumContainersCheck) Run() error {
 		return ErrExpectedMinNumContainers
 	}
 	return nil
+}
+
+// Suggestion implements common.Runnable
+func (check MinNumContainersCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (check MinNumContainersCheck) FixIt() error {
+	panic("implement me")
 }

--- a/pkg/kubernetes/pod/events.go
+++ b/pkg/kubernetes/pod/events.go
@@ -52,3 +52,13 @@ func (check NoBadEventsCheck) Run() error {
 
 	return fmt.Errorf("pod '%s' has events that are of 'type!=Normal' - run 'kubectl get events --field-selector %s' to inspect events", check.pod.Name, selectorString)
 }
+
+// Suggestion implements common.Runnable.
+func (check NoBadEventsCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable.
+func (check NoBadEventsCheck) FixIt() error {
+	panic("implement me")
+}

--- a/pkg/kubernetes/pod/labels.go
+++ b/pkg/kubernetes/pod/labels.go
@@ -10,13 +10,16 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
+// Verify interface compliance
+var _ common.Runnable = (*ProxyUUIDLabelCheck)(nil)
+
 // ProxyUUIDLabelCheck implements common.Runnable
 type ProxyUUIDLabelCheck struct {
 	pod *v1.Pod
 }
 
 // HasProxyUUIDLabel checks whether a pod has a valid proxy UUID label which is added when a pod is added to a mesh
-func HasProxyUUIDLabel(pod *v1.Pod) common.Runnable {
+func HasProxyUUIDLabel(pod *v1.Pod) ProxyUUIDLabelCheck {
 	return ProxyUUIDLabelCheck{
 		pod: pod,
 	}
@@ -33,6 +36,16 @@ func (check ProxyUUIDLabelCheck) Run() error {
 		return ErrProxyUUIDLabelMissing
 	}
 	return nil
+}
+
+// Suggestion implements common.Runnable
+func (check ProxyUUIDLabelCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (check ProxyUUIDLabelCheck) FixIt() error {
+	panic("implement me")
 }
 
 // TODO: replace with function from osm pkg once it's made public


### PR DESCRIPTION
This PR adds 2 new functions to the `Runnable` interface:
 - `Suggestion()` - returns a string with a suggestion on how to fix an error that may have been discovered (or an empty string if no error is discovered)
 - `FixIt()` - actually applies the fix suggested by the previous function


Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>