### PR TITLE
chore(pkg/kubernetes): Use osm mesh pkg for proxy label check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,15 +9,14 @@ require (
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e // indirect
 	github.com/golang/mock v1.4.4 // indirect
-	github.com/golang/protobuf v1.4.3
-	github.com/google/uuid v1.1.2 // indirect
 	github.com/golang/protobuf v1.5.2
+	github.com/google/uuid v1.1.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39 // indirect
-	github.com/openservicemesh/osm v0.8.2-0.20210730182412-e003a65c2cb5
+	github.com/openservicemesh/osm v0.8.2-0.20210802225558-b607bba099c1
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.23.0
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -846,6 +846,8 @@ github.com/openservicemesh/osm v0.8.2-0.20210730180737-9be251135819 h1:+AENmJjsX
 github.com/openservicemesh/osm v0.8.2-0.20210730180737-9be251135819/go.mod h1:ABKbMdxIUw9FPISOL0ouw7oH9YptNVLD4PpZ6Y/omgI=
 github.com/openservicemesh/osm v0.8.2-0.20210730182412-e003a65c2cb5 h1:FeQoI5dkUvK6n7nkIWd72t8+CW+V6gGysXJtpJYHCFY=
 github.com/openservicemesh/osm v0.8.2-0.20210730182412-e003a65c2cb5/go.mod h1:ABKbMdxIUw9FPISOL0ouw7oH9YptNVLD4PpZ6Y/omgI=
+github.com/openservicemesh/osm v0.8.2-0.20210802225558-b607bba099c1 h1:vKk+AWqGjiaD9qSsdN1L9qVP8X3pwrqeGBSdRf0/Umk=
+github.com/openservicemesh/osm v0.8.2-0.20210802225558-b607bba099c1/go.mod h1:ABKbMdxIUw9FPISOL0ouw7oH9YptNVLD4PpZ6Y/omgI=
 github.com/openservicemesh/osm v0.9.1 h1:/u5BF2sW6oPka2GLPOyt/ojA8MfKmRmD/tqKVwkimMY=
 github.com/openservicemesh/osm v0.9.1/go.mod h1:r0cPM8bz8j7RD3ZTcycfaWS0rS45sE3nXtgHgRfBb6k=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=

--- a/pkg/kubernetes/pod/labels.go
+++ b/pkg/kubernetes/pod/labels.go
@@ -3,11 +3,10 @@ package pod
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
-	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/mesh"
 )
 
 // ProxyUUIDLabelCheck implements common.Runnable
@@ -29,21 +28,8 @@ func (check ProxyUUIDLabelCheck) Info() string {
 
 // Run implements common.Runnable
 func (check ProxyUUIDLabelCheck) Run() error {
-	if !proxyLabelExists(check.pod) {
+	if !mesh.ProxyLabelExists(*check.pod) {
 		return ErrProxyUUIDLabelMissing
 	}
 	return nil
-}
-
-// TODO: replace with function from osm pkg once it's made public
-// proxyLabelExists returns a boolean indicating whether the pod has a proxy UUID label. A proxy UUID label is added when a pod is added to a mesh
-func proxyLabelExists(pod *v1.Pod) bool {
-	// osm-controller adds a unique label to each pod when it is added to a mesh
-	proxyUUID, proxyLabelSet := pod.Labels[constants.EnvoyUniqueIDLabelName]
-	return proxyLabelSet && isValidUUID(proxyUUID)
-}
-
-func isValidUUID(u string) bool {
-	_, err := uuid.Parse(u)
-	return err == nil
 }


### PR DESCRIPTION
Use the proxy label check in `openservicemesh/osm/pkg/mesh`.

This is a follow up to https://github.com/openservicemesh/osm/pull/3899

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>