### PR TITLE
fix(envoy): add HTTP health check filter import for parse

### DIFF
--- a/pkg/envoy/parse.go
+++ b/pkg/envoy/parse.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"

--- a/tests/sample-enovy-config-dump-bookstore.json
+++ b/tests/sample-enovy-config-dump-bookstore.json
@@ -1501,6 +1501,26 @@
        }
       },
       "connect_timeout": "1s",
+      "health_checks": [
+       {
+        "timeout": "1s",
+        "interval": "10s",
+        "unhealthy_threshold": 3,
+        "healthy_threshold": 1,
+        "http_health_check": {
+         "host": "bookwarehouse.bookwarehouse.svc.cluster.local",
+         "path": "/healthz/osm",
+         "request_headers_to_add": [
+          {
+           "header": {
+            "key": "x-osm-envoy-healthcheck",
+            "value": "1"
+           }
+          }
+         ]
+        }
+       }
+      ],
       "transport_socket": {
        "name": "envoy.transport_sockets.tls",
        "typed_config": {
@@ -2309,6 +2329,23 @@
                  "allow_precompiled": true
                 }
                }
+              }
+             },
+             {
+              "name": "envoy.filters.http.health_check",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck",
+               "pass_through_mode": false,
+               "headers": [
+                {
+                 "name": ":path",
+                 "exact_match": "/healthz/osm"
+                },
+                {
+                 "name": "x-osm-envoy-healthcheck",
+                 "present_match": true
+                }
+               ]
               }
              },
              {


### PR DESCRIPTION
This change imports the HTTP health check filter package for parsing the
Envoy config to succeed when Envoy active health checks are enabled.