### PR TITLE
Adding the wireframe of a new POD to URL check

### DIFF
--- a/cmd/connectivity.go
+++ b/cmd/connectivity.go
@@ -17,5 +17,6 @@ func newConnectivityCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	cmd.AddCommand(newConnectivityPodToPodCmd())
+	cmd.AddCommand(newConnectivityPodToURLCmd())
 	return cmd
 }

--- a/cmd/connectivity_pod_to_url.go
+++ b/cmd/connectivity_pod_to_url.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/openservicemesh/osm-health/pkg/connectivity"
+	"github.com/openservicemesh/osm-health/pkg/kuberneteshelper"
+)
+
+const connectivityPodToURLDesc = `
+Checks connectivity between Kubernetes pods
+	(add more descriptive description)
+`
+
+const connectivityPodToURLExample = `
+Example:
+	(add example)
+`
+
+func newConnectivityPodToURLCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "pod-to-url SOURCE_POD DESTINATION_URL",
+		Short:   "Checks connectivity between a Kubernetes pod and a given URL",
+		Example: connectivityPodToURLExample,
+		Long:    connectivityPodToURLDesc,
+		Args:    cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return errors.Errorf("provide both SOURCE_POD and DESTINATION_URL")
+			}
+
+			fromPod, err := kuberneteshelper.PodFromString(args[0])
+			if err != nil {
+				return errors.New("invalid SOURCE_POD")
+			}
+
+			toURL, err := url.Parse(args[1])
+			if err != nil {
+				return errors.New("invalid DESTINATION_URL")
+			}
+
+			connectivity.PodToURL(fromPod, toURL)
+			return nil
+		},
+	}
+}

--- a/pkg/connectivity/pod-to-url.go
+++ b/pkg/connectivity/pod-to-url.go
@@ -9,19 +9,8 @@ import (
 )
 
 // PodToURL tests the connectivity between a source pod and destination url.
-func PodToURL(fromPod *v1.Pod, destinationURL *url.URL) common.Result {
+func PodToURL(fromPod *v1.Pod, destinationURL *url.URL) {
 	log.Info().Msgf("Testing connectivity from %s/%s to %s", fromPod.Namespace, fromPod.Name, destinationURL)
-
 	outcomes := common.Run()
-
 	common.Print(outcomes...)
-
-	return common.Result{
-		SMIPolicy: common.SMIPolicy{
-			HasPolicy:                  false,
-			ValidPolicy:                false,
-			SourceToDestinationAllowed: false,
-		},
-		Successful: false,
-	}
 }

--- a/pkg/connectivity/pod-to-url.go
+++ b/pkg/connectivity/pod-to-url.go
@@ -1,0 +1,27 @@
+package connectivity
+
+import (
+	"net/url"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm-health/pkg/common"
+)
+
+// PodToURL tests the connectivity between a source pod and destination url.
+func PodToURL(fromPod *v1.Pod, destinationURL *url.URL) common.Result {
+	log.Info().Msgf("Testing connectivity from %s/%s to %s", fromPod.Namespace, fromPod.Name, destinationURL)
+
+	outcomes := common.Run()
+
+	common.Print(outcomes...)
+
+	return common.Result{
+		SMIPolicy: common.SMIPolicy{
+			HasPolicy:                  false,
+			ValidPolicy:                false,
+			SourceToDestinationAllowed: false,
+		},
+		Successful: false,
+	}
+}

--- a/tests/pod-to-url.sh
+++ b/tests/pod-to-url.sh
@@ -18,14 +18,13 @@ kubectl create namespace bookstore
 ./bin/osm namespace add bookstore
 
 for x in bookbuyer bookstore; do
-    while [[ $(kubectl get pods -n "$x" -l "app=${x}" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
-        echo "waiting for pod ${x}" && sleep 1
-    done
+  while [[ $(kubectl get pods -n "$x" -l "app=${x}" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+    echo "waiting for pod ${x}" && sleep 1
+  done
 done
 
 POD1=$(kubectl get pod -n bookbuyer --selector app=bookbuyer --no-headers | awk '{print $1}')
-POD2=$(kubectl get pod -n bookstore --selector app=bookstore --no-headers | awk '{print $1}')
 
-./bin/osm-health connectivity pod-to-pod \
+./bin/osm-health connectivity pod-to-url \
                  "bookbuyer/${POD1}" \
-                 "bookstore/${POD2}"
+                 "http://bookstore.bookstore/"


### PR DESCRIPTION
This PR adds a wireframe for a new check from a given POD to an URL.

Example:
```bash
./bin/osm-health connectivity pod-to-url \
                 "bookbuyer/bookbuyer-8858fb5f6-cvlxz" \
                 "http://bookstore.bookstore/"
```

---

Run this with:
```bash
rm -rf ./bin/osm-health && make && ./tests/pod-to-url.sh
```

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>