### PR TITLE
feat(connectivity): add CDS cluster name check

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -307,6 +307,7 @@ github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui72
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -68,6 +68,9 @@ func PodToPod(fromPod *v1.Pod, toPod *v1.Pod) common.Result {
 
 		// Destination Envoy must have Inbound listener
 		envoy.HasInboundListener(dstConfigGetter, osmVersion),
+
+		// Source Envoy must define a cluster for the destination
+		envoy.HasCluster(client, srcConfigGetter, toPod),
 	)
 
 	common.Print(outcomes...)

--- a/pkg/envoy/cds.go
+++ b/pkg/envoy/cds.go
@@ -1,0 +1,133 @@
+package envoy
+
+import (
+	"context"
+	"fmt"
+
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm-health/pkg/common"
+	"github.com/openservicemesh/osm/pkg/utils"
+)
+
+// HasClusterCheck implements common.Runnable
+type HasClusterCheck struct {
+	ConfigGetter
+
+	dstPod *corev1.Pod
+	k8s    kubernetes.Interface
+}
+
+// Run implements common.Runnable
+func (c HasClusterCheck) Run() error {
+	if c.ConfigGetter == nil {
+		log.Error().Msg("Incorrectly initialized ConfigGetter")
+		return ErrIncorrectlyInitializedConfigGetter
+	}
+	envoyConfig, err := c.ConfigGetter.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if envoyConfig == nil {
+		return ErrEnvoyConfigEmpty
+	}
+
+	// The destination Pod might back multiple services, so check that at least
+	// one of those services is listed as a cluster in the source Envoy config.
+	possibleClusterNames := map[string]struct{}{}
+	svcs, err := c.listServicesForPod()
+	if err != nil {
+		return errors.Wrapf(err, "failed to map Pod %s/%s to Kubernetes Services", c.dstPod.Namespace, c.dstPod.Name)
+	}
+	for _, svc := range svcs {
+		possibleClusterNames[utils.K8sSvcToMeshSvc(svc).String()] = struct{}{}
+	}
+	if len(possibleClusterNames) == 0 {
+		// This pod isn't backing any services, so we wouldn't expect a cluster
+		// to be listed in the Envoy config.
+		return nil
+	}
+
+	found := false
+	var foundClusterNames []string
+	for _, dynCluster := range envoyConfig.Clusters.DynamicActiveClusters {
+		var cluster clusterv3.Cluster
+		err := dynCluster.Cluster.UnmarshalTo(&cluster)
+		if err != nil {
+			log.Error().Err(err).Msgf("failed to unmarshal cluster %s", dynCluster.String())
+			continue
+		}
+		foundClusterNames = append(foundClusterNames, cluster.Name)
+
+		if _, exists := possibleClusterNames[cluster.Name]; exists {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		var expectedClusterNames []string
+		for name := range possibleClusterNames {
+			expectedClusterNames = append(expectedClusterNames, name)
+		}
+		return fmt.Errorf("Expected a cluster named one of %v, but only found %v", expectedClusterNames, foundClusterNames)
+	}
+	return nil
+}
+
+func (c HasClusterCheck) listServicesForPod() ([]*corev1.Service, error) {
+	var serviceList []*corev1.Service
+	svcList, err := c.k8s.CoreV1().Services(c.dstPod.Namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list services in namespace %s", c.dstPod.Namespace)
+	}
+
+	for _, svc := range svcList.Items {
+		svc := svc
+		if svc.Namespace != c.dstPod.Namespace {
+			continue
+		}
+		svcRawSelector := svc.Spec.Selector
+		// service has no selectors, we do not need to match against the pod label
+		if len(svcRawSelector) == 0 {
+			continue
+		}
+		selector := labels.SelectorFromSet(svcRawSelector)
+		if selector.Matches(labels.Set(c.dstPod.Labels)) {
+			serviceList = append(serviceList, &svc)
+		}
+	}
+
+	return serviceList, nil
+}
+
+// Suggestion implements common.Runnable
+func (c HasClusterCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (c HasClusterCheck) FixIt() error {
+	panic("implement me")
+}
+
+// Info implements common.Runnable
+func (c HasClusterCheck) Info() string {
+	return fmt.Sprintf("Checking whether %s is configured with an envoy cluster referring to Pod %s/%s", c.ConfigGetter.GetObjectName(), c.dstPod.Namespace, c.dstPod.Name)
+}
+
+// HasCluster creates a new common.Runnable, which checks whether the given Pod
+// has an Envoy with properly configured cluster.
+func HasCluster(client kubernetes.Interface, configGetter ConfigGetter, dstPod *corev1.Pod) common.Runnable {
+	return HasClusterCheck{
+		ConfigGetter: configGetter,
+		dstPod:       dstPod,
+		k8s:          client,
+	}
+}

--- a/pkg/envoy/cds_test.go
+++ b/pkg/envoy/cds_test.go
@@ -1,0 +1,191 @@
+package envoy
+
+import (
+	"testing"
+
+	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/golang/protobuf/ptypes"
+	any "github.com/golang/protobuf/ptypes/any"
+	tassert "github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEnvoyClusterChecker(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+		dstPod *corev1.Pod
+		svcs   []*corev1.Service
+		pass   bool
+	}{
+		{
+			name: "pod matches one service with cluster in config",
+			config: &Config{
+				Clusters: adminv3.ClustersConfigDump{
+					DynamicActiveClusters: []*adminv3.ClustersConfigDump_DynamicCluster{
+						{
+							Cluster: marshalClusterOrDie(&clusterv3.Cluster{
+								Name: "mynamespace/myservice",
+							}),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+			},
+			svcs: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myservice",
+						Namespace: "mynamespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"mykey": "myval",
+						},
+					},
+				},
+			},
+			pass: true,
+		},
+		{
+			name: "pod matches one service without cluster in config",
+			config: &Config{
+				Clusters: adminv3.ClustersConfigDump{
+					DynamicActiveClusters: []*adminv3.ClustersConfigDump_DynamicCluster{
+						{
+							Cluster: marshalClusterOrDie(&clusterv3.Cluster{
+								Name: "mynamespace/not-myservice",
+							}),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+			},
+			svcs: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myservice",
+						Namespace: "mynamespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"mykey": "myval",
+						},
+					},
+				},
+			},
+			pass: false,
+		},
+		{
+			name: "pod matches two services with one cluster in config",
+			config: &Config{
+				Clusters: adminv3.ClustersConfigDump{
+					DynamicActiveClusters: []*adminv3.ClustersConfigDump_DynamicCluster{
+						{
+							Cluster: marshalClusterOrDie(&clusterv3.Cluster{
+								Name: "mynamespace/myservice",
+							}),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+			},
+			svcs: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myservice",
+						Namespace: "mynamespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"mykey": "myval",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myservice2",
+						Namespace: "mynamespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"mykey": "myval",
+						},
+					},
+				},
+			},
+			pass: true,
+		},
+		{
+			name:   "pod matches no services with no clusters",
+			config: &Config{},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+				},
+			},
+			svcs: nil,
+			pass: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			configGetter := mockConfigGetter{
+				getter: func() (*Config, error) {
+					return test.config, nil
+				},
+			}
+			objs := make([]runtime.Object, len(test.svcs))
+			for i := range test.svcs {
+				objs[i] = test.svcs[i]
+			}
+			k8s := fake.NewSimpleClientset(objs...)
+			clusterChecker := HasCluster(k8s, configGetter, test.dstPod)
+			err := clusterChecker.Run()
+			if test.pass {
+				assert.NoError(err)
+			} else {
+				assert.Error(err)
+			}
+		})
+	}
+}
+
+func marshalClusterOrDie(cluster *clusterv3.Cluster) *any.Any {
+	a, err := ptypes.MarshalAny(cluster)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}


### PR DESCRIPTION
This change adds a new check in the pod-to-pod connectivity checks that
verifies the source Envoy config contains a cluster with a name matching
one of the Kubernetes services the destination pod is backing.