### PR TITLE
format(printer): add colors to test outcomes

### DIFF
--- a/pkg/common/printer.go
+++ b/pkg/common/printer.go
@@ -1,6 +1,10 @@
 package common
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
 
 // Print prints the outcomes of the evaluation of a list of Runnables.
 func Print(outcomes ...Outcome) {
@@ -8,9 +12,9 @@ func Print(outcomes ...Outcome) {
 	foundIssues := false
 	for idx, issue := range outcomes {
 		foundIssues = foundIssues && issue.Error != nil
-		errString := "OK"
+		errString := color.GreenString("OK")
 		if issue.Error != nil {
-			errString = fmt.Sprintf("FAIL: %s", issue.Error.Error())
+			errString = fmt.Sprintf("%s %s", color.RedString("FAIL:"), color.RedString(issue.Error.Error()))
 			issuesCount = issuesCount + 1
 		}
 		fmt.Printf("%d  %s  -- %s\n", idx+1, issue.RunnableInfo, errString)


### PR DESCRIPTION
Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>

Yay for colors! Follow up PR coming soon for formatting outcomes in a table

Before:
![image](https://user-images.githubusercontent.com/42152676/128250567-42c17112-c1cf-4603-8e5a-620b49c0c619.png)

After:
![image](https://user-images.githubusercontent.com/42152676/128250506-9640bd85-e5d5-4437-a2bd-9d0ad076778a.png)
