### PR TITLE
fix(connectivity): check all LDS listeners

### DIFF
--- a/pkg/envoy/lds.go
+++ b/pkg/envoy/lds.go
@@ -46,10 +46,18 @@ func (l HasListenerCheck) Run() error {
 		return ErrEnvoyConfigEmpty
 	}
 
-	actualListener := envoyConfig.Listeners.DynamicListeners[0]
+	found := false
+	var actualListeners []string
+	for _, actualListener := range envoyConfig.Listeners.GetDynamicListeners() {
+		actualListeners = append(actualListeners, actualListener.Name)
+		if expectedListenerName == actualListener.Name {
+			found = true
+			break
+		}
+	}
 
-	if expectedListenerName != actualListener.Name {
-		log.Error().Msgf("must have listener with name %s but it is instead %s", expectedListenerName, actualListener.Name)
+	if !found {
+		log.Error().Msgf("must have listener with name %s but only found %s", expectedListenerName, actualListeners)
 		return ErrEnvoyListenerMissing
 	}
 

--- a/pkg/envoy/lds_test.go
+++ b/pkg/envoy/lds_test.go
@@ -26,14 +26,14 @@ func TestEnvoyListenerChecker(t *testing.T) {
 	osmVersion := osm.ControllerVersion("v0.9")
 	configGetter := mockConfigGetter{
 		getter: func() (*Config, error) {
-			sampleConfig, err := os.ReadFile("../../tests/sample-enovy-config-dump-bookbuyer.json")
+			sampleConfig, err := os.ReadFile("../../tests/sample-enovy-config-dump-bookstore.json")
 			if err != nil {
 				return nil, err
 			}
 			return ParseEnvoyConfig(sampleConfig)
 		},
 	}
-	listenerChecker := HasOutboundListener(configGetter, osmVersion)
+	listenerChecker := HasInboundListener(configGetter, osmVersion)
 	checkError := listenerChecker.Run()
 	assert.Nil(checkError)
 }


### PR DESCRIPTION
This change fixes the listener checks for pod-to-pod connectivity to
look in all of the listeners, not just the first.