### PR TITLE
check(monitored): are namespaces in the same mesh

### DIFF
--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -37,6 +37,9 @@ func PodToPod(fromPod *v1.Pod, toPod *v1.Pod) {
 	}
 
 	outcomes := common.Run(
+		// Check that pod namespaces are in the same mesh
+		namespace.AreNamespacesInSameMesh(client, fromPod.Namespace, toPod.Namespace),
+
 		// Check source Pod's namespace
 		namespace.IsInjectEnabled(client, fromPod.Namespace),
 		namespace.IsMonitoredBy(client, fromPod.Namespace, meshName),

--- a/pkg/kubernetes/namespace/errors.go
+++ b/pkg/kubernetes/namespace/errors.go
@@ -10,4 +10,7 @@ var (
 
 	// ErrNotMonitoredByOSMController is used when namespace is expected to be monitored by OSM but is not.
 	ErrNotMonitoredByOSMController = errors.New("not monitored by OSM controller")
+
+	// ErrNamespacesNotInSameMesh is used when two given namespaces are not in the same mesh
+	ErrNamespacesNotInSameMesh = errors.New("namespaces not monitored by the same mesh")
 )

--- a/pkg/kubernetes/namespace/monitored.go
+++ b/pkg/kubernetes/namespace/monitored.go
@@ -59,3 +59,60 @@ func (check MonitoredCheck) Suggestion() string {
 func (check MonitoredCheck) FixIt() error {
 	panic("implement me")
 }
+
+// Verify interface compliance
+var _ common.Runnable = (*NamespacesInSameMeshCheck)(nil)
+
+// NamespacesInSameMeshCheck implements common.Runnable
+type NamespacesInSameMeshCheck struct {
+	client     kubernetes.Interface
+	namespaceA string
+	namespaceB string
+}
+
+// AreNamespacesInSameMesh checks whether two pods are in the same mesh
+func AreNamespacesInSameMesh(client kubernetes.Interface, namespaceA string, namespaceB string) NamespacesInSameMeshCheck {
+	return NamespacesInSameMeshCheck{
+		client:     client,
+		namespaceA: namespaceA,
+		namespaceB: namespaceB,
+	}
+}
+
+// Info implements common.Runnable
+func (check NamespacesInSameMeshCheck) Info() string {
+	return fmt.Sprintf("Checking whether namespace %s and namespace %s are monitored by the same mesh", check.namespaceA, check.namespaceB)
+}
+
+// Run implements common.Runnable
+func (check NamespacesInSameMeshCheck) Run() error {
+	labelsA, err := getLabels(check.client, check.namespaceA)
+	if err != nil {
+		return err
+	}
+	meshNameA, labelExistsA := labelsA[constants.OSMKubeResourceMonitorAnnotation]
+
+	labelsB, err := getLabels(check.client, check.namespaceB)
+	if err != nil {
+		return err
+	}
+
+	meshNameB, labelExistsB := labelsB[constants.OSMKubeResourceMonitorAnnotation]
+	if !labelExistsA || !labelExistsB {
+		return ErrNotMonitoredByOSMController
+	}
+	if meshNameA != meshNameB {
+		return ErrNamespacesNotInSameMesh
+	}
+	return nil
+}
+
+// Suggestion implements common.Runnable
+func (check NamespacesInSameMeshCheck) Suggestion() string {
+	return fmt.Sprintf("Verify which mesh each namespace is monitored by. Try: \"kubectl get namespace -n %s -o json | jq '.items[0].metadata.labels'\"", check.namespaceA)
+}
+
+// FixIt implements common.Runnable
+func (check NamespacesInSameMeshCheck) FixIt() error {
+	panic("implement me")
+}


### PR DESCRIPTION
May be unnecessary, does similar work to the isMonitoredBy check. Would make sense to move into pkg/kubernetes/namespace

Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>