### PR TITLE
chore(*): refactor corev1 and metav1 imports

### DIFF
--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -1,7 +1,7 @@
 package connectivity
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
 	"github.com/openservicemesh/osm-health/pkg/envoy"
@@ -12,7 +12,7 @@ import (
 )
 
 // PodToPod tests the connectivity between a source and destination pods.
-func PodToPod(fromPod *v1.Pod, toPod *v1.Pod, osmControlPlaneNamespace string) {
+func PodToPod(fromPod *corev1.Pod, toPod *corev1.Pod, osmControlPlaneNamespace string) {
 	log.Info().Msgf("Testing connectivity from %s/%s to %s/%s", fromPod.Namespace, fromPod.Name, toPod.Namespace, toPod.Name)
 
 	// TODO

--- a/pkg/connectivity/pod-to-url.go
+++ b/pkg/connectivity/pod-to-url.go
@@ -3,13 +3,13 @@ package connectivity
 import (
 	"net/url"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
 )
 
 // PodToURL tests the connectivity between a source pod and destination url.
-func PodToURL(fromPod *v1.Pod, destinationURL *url.URL) {
+func PodToURL(fromPod *corev1.Pod, destinationURL *url.URL) {
 	log.Info().Msgf("Testing connectivity from %s/%s to %s", fromPod.Namespace, fromPod.Name, destinationURL)
 	outcomes := common.Run()
 	common.Print(outcomes...)

--- a/pkg/envoy/config.go
+++ b/pkg/envoy/config.go
@@ -3,7 +3,7 @@ package envoy
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm-health/pkg/kuberneteshelper"
 	"github.com/openservicemesh/osm-health/pkg/osm"
@@ -12,7 +12,7 @@ import (
 
 // ConfigGetterStruct implements ConfigGetter interface.
 type ConfigGetterStruct struct {
-	*v1.Pod
+	*corev1.Pod
 	osm.ControllerVersion
 }
 
@@ -47,7 +47,7 @@ func (mcg ConfigGetterStruct) GetObjectName() string {
 }
 
 // GetEnvoyConfigGetterForPod returns a ConfigGetter struct, which can fetch the Envoy config for the given pod.
-func GetEnvoyConfigGetterForPod(pod *v1.Pod, osmVersion osm.ControllerVersion) (ConfigGetter, error) {
+func GetEnvoyConfigGetterForPod(pod *corev1.Pod, osmVersion osm.ControllerVersion) (ConfigGetter, error) {
 	return ConfigGetterStruct{
 		Pod:               pod,
 		ControllerVersion: osmVersion,

--- a/pkg/envoy/eds.go
+++ b/pkg/envoy/eds.go
@@ -3,9 +3,8 @@ package envoy
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
 )
@@ -15,7 +14,7 @@ var _ common.Runnable = (*DestinationEndpointChecker)(nil)
 
 // DestinationEndpointChecker implements common.Runnable
 type DestinationEndpointChecker struct {
-	*v1.Pod
+	*corev1.Pod
 	ConfigGetter
 }
 
@@ -104,7 +103,7 @@ func HasDestinationEndpoints(configGetter ConfigGetter) DestinationEndpointCheck
 // HasSpecificEndpoint creates a new common.Runnable, which checks whether the
 // given Pod has an Envoy with an endpoint configured mapping to a specific
 // destination Pod.
-func HasSpecificEndpoint(configGetter ConfigGetter, pod *v1.Pod) DestinationEndpointChecker {
+func HasSpecificEndpoint(configGetter ConfigGetter, pod *corev1.Pod) DestinationEndpointChecker {
 	return DestinationEndpointChecker{
 		ConfigGetter: configGetter,
 		Pod:          pod,

--- a/pkg/envoy/envoy_container_logs.go
+++ b/pkg/envoy/envoy_container_logs.go
@@ -3,7 +3,7 @@ package envoy
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
@@ -16,11 +16,11 @@ var _ common.Runnable = (*NoBadEnvoyLogsCheck)(nil)
 // NoBadEnvoyLogsCheck implements common.Runnable
 type NoBadEnvoyLogsCheck struct {
 	client kubernetes.Interface
-	pod    *v1.Pod
+	pod    *corev1.Pod
 }
 
 // HasNoBadEnvoyLogsCheck checks whether the envoy container of the pod has bad (fatal/error/warning/fail) log messages
-func HasNoBadEnvoyLogsCheck(client kubernetes.Interface, pod *v1.Pod) NoBadEnvoyLogsCheck {
+func HasNoBadEnvoyLogsCheck(client kubernetes.Interface, pod *corev1.Pod) NoBadEnvoyLogsCheck {
 	return NoBadEnvoyLogsCheck{
 		client: client,
 		pod:    pod,

--- a/pkg/ingress/pod.go
+++ b/pkg/ingress/pod.go
@@ -1,7 +1,7 @@
 package ingress
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
@@ -9,7 +9,7 @@ import (
 )
 
 // ToPod checks the Ingress to the given pod.
-func ToPod(client kubernetes.Interface, toPod *v1.Pod) {
+func ToPod(client kubernetes.Interface, toPod *corev1.Pod) {
 	log.Info().Msgf("Testing ingress to pod %s/%s", toPod.Namespace, toPod.Name)
 
 	// TODO

--- a/pkg/kubernetes/namespace/annotations.go
+++ b/pkg/kubernetes/namespace/annotations.go
@@ -3,12 +3,12 @@ package namespace
 import (
 	"context"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 func getAnnotations(client kubernetes.Interface, namespace string) (map[string]string, error) {
-	ns, err := client.CoreV1().Namespaces().Get(context.TODO(), namespace, v1.GetOptions{})
+	ns, err := client.CoreV1().Namespaces().Get(context.TODO(), namespace, corev1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/namespace/labels.go
+++ b/pkg/kubernetes/namespace/labels.go
@@ -3,12 +3,12 @@ package namespace
 import (
 	"context"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 func getLabels(client kubernetes.Interface, namespace string) (map[string]string, error) {
-	ns, err := client.CoreV1().Namespaces().Get(context.TODO(), namespace, v1.GetOptions{})
+	ns, err := client.CoreV1().Namespaces().Get(context.TODO(), namespace, corev1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/podhelper/container_logs.go
+++ b/pkg/kubernetes/podhelper/container_logs.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/pkg/errors"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 // HasNoBadLogs checks whether the logs of the pod container contain bad (fatal/error/warning/fail) logs
-func HasNoBadLogs(client kubernetes.Interface, pod *v1.Pod, containerName string) error {
+func HasNoBadLogs(client kubernetes.Interface, pod *corev1.Pod, containerName string) error {
 	logsTailLines := int64(10)
-	podLogsOpt := v1.PodLogOptions{
+	podLogsOpt := corev1.PodLogOptions{
 		Container: containerName,
 		Follow:    false,
 		Previous:  false,

--- a/pkg/kubernetes/podhelper/containers.go
+++ b/pkg/kubernetes/podhelper/containers.go
@@ -3,7 +3,7 @@ package podhelper
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -15,11 +15,11 @@ var _ common.Runnable = (*EnvoySidecarImageCheck)(nil)
 // EnvoySidecarImageCheck implements common.Runnable
 type EnvoySidecarImageCheck struct {
 	cfg configurator.Configurator
-	pod *v1.Pod
+	pod *corev1.Pod
 }
 
 // HasExpectedEnvoyImage checks whether a pod has a sidecar with the envoy image specified in the meshconfig
-func HasExpectedEnvoyImage(osmConfigurator configurator.Configurator, pod *v1.Pod) EnvoySidecarImageCheck {
+func HasExpectedEnvoyImage(osmConfigurator configurator.Configurator, pod *corev1.Pod) EnvoySidecarImageCheck {
 	return EnvoySidecarImageCheck{
 		cfg: osmConfigurator,
 		pod: pod,
@@ -57,11 +57,11 @@ var _ common.Runnable = (*OsmInitContainerImageCheck)(nil)
 // OsmInitContainerImageCheck implements common.Runnable
 type OsmInitContainerImageCheck struct {
 	cfg configurator.Configurator
-	pod *v1.Pod
+	pod *corev1.Pod
 }
 
 // HasExpectedOsmInitImage checks whether a pod has a sidecar with the osm init container image specified in the meshconfig
-func HasExpectedOsmInitImage(osmConfigurator configurator.Configurator, pod *v1.Pod) OsmInitContainerImageCheck {
+func HasExpectedOsmInitImage(osmConfigurator configurator.Configurator, pod *corev1.Pod) OsmInitContainerImageCheck {
 	return OsmInitContainerImageCheck{
 		cfg: osmConfigurator,
 		pod: pod,
@@ -98,13 +98,13 @@ var _ common.Runnable = (*MinNumContainersCheck)(nil)
 
 // MinNumContainersCheck implements common.Runnable
 type MinNumContainersCheck struct {
-	pod    *v1.Pod
+	pod    *corev1.Pod
 	minNum int
 }
 
 // HasMinExpectedContainers checks whether a pod has at least the min number of containers expected
 // This currently corresponds to an app container, osm init container and envoy proxy sidecar
-func HasMinExpectedContainers(pod *v1.Pod, num int) MinNumContainersCheck {
+func HasMinExpectedContainers(pod *corev1.Pod, num int) MinNumContainersCheck {
 	return MinNumContainersCheck{
 		pod:    pod,
 		minNum: num,

--- a/pkg/kubernetes/podhelper/events.go
+++ b/pkg/kubernetes/podhelper/events.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -18,11 +17,11 @@ var _ common.Runnable = (*NoBadEventsCheck)(nil)
 // NoBadEventsCheck implements common.Runnable
 type NoBadEventsCheck struct {
 	client kubernetes.Interface
-	pod    *v1.Pod
+	pod    *corev1.Pod
 }
 
 // DoesNotHaveBadEvents checks whether a pod has abnormal (type!=Normal) events
-func DoesNotHaveBadEvents(client kubernetes.Interface, pod *v1.Pod) NoBadEventsCheck {
+func DoesNotHaveBadEvents(client kubernetes.Interface, pod *corev1.Pod) NoBadEventsCheck {
 	return NoBadEventsCheck{
 		client: client,
 		pod:    pod,

--- a/pkg/kubernetes/podhelper/labels.go
+++ b/pkg/kubernetes/podhelper/labels.go
@@ -3,7 +3,7 @@ package podhelper
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm-health/pkg/common"
 	"github.com/openservicemesh/osm/pkg/mesh"
@@ -14,11 +14,11 @@ var _ common.Runnable = (*ProxyUUIDLabelCheck)(nil)
 
 // ProxyUUIDLabelCheck implements common.Runnable
 type ProxyUUIDLabelCheck struct {
-	pod *v1.Pod
+	pod *corev1.Pod
 }
 
 // HasProxyUUIDLabel checks whether a pod has a valid proxy UUID label which is added when a pod is added to a mesh
-func HasProxyUUIDLabel(pod *v1.Pod) ProxyUUIDLabelCheck {
+func HasProxyUUIDLabel(pod *corev1.Pod) ProxyUUIDLabelCheck {
 	return ProxyUUIDLabelCheck{
 		pod: pod,
 	}

--- a/pkg/kuberneteshelper/pod.go
+++ b/pkg/kuberneteshelper/pod.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -19,7 +19,7 @@ import (
 )
 
 // PodFromString validates the name of the Pod
-func PodFromString(namespacedPod string) (*v1.Pod, error) {
+func PodFromString(namespacedPod string) (*corev1.Pod, error) {
 	podChunks := strings.Split(namespacedPod, "/")
 	if len(podChunks) != 2 {
 		log.Fatal().Msgf("Invalid Pod name %s; This is expected to be in the format: namespace/name", namespacedPod)
@@ -37,7 +37,7 @@ func PodFromString(namespacedPod string) (*v1.Pod, error) {
 		return nil, err
 	}
 
-	podList, err := kubeClient.CoreV1().Pods(namespace).List(context.Background(), v12.ListOptions{})
+	podList, err := kubeClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		log.Err(err).Msg("Error getting list of Pods")
 		return nil, errors.New("error getting pods")


### PR DESCRIPTION
This resolves inconsistent imports of corev1 and metav1 imports.

From this point onwards, imports for both packages should
always be "corev1" and "metav1" by convention in this repo.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>