### PR TITLE
smi(checks): add checks for traffic target and valid route

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39 // indirect
-	github.com/openservicemesh/osm v0.8.2-0.20210802225558-b607bba099c1
+	github.com/openservicemesh/osm v0.8.2-0.20210823171715-5fba2d3f778b
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.23.0
 	github.com/servicemeshinterface/smi-sdk-go v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1131,6 +1131,8 @@ github.com/openservicemesh/osm v0.8.2-0.20210730182412-e003a65c2cb5 h1:FeQoI5dkU
 github.com/openservicemesh/osm v0.8.2-0.20210730182412-e003a65c2cb5/go.mod h1:ABKbMdxIUw9FPISOL0ouw7oH9YptNVLD4PpZ6Y/omgI=
 github.com/openservicemesh/osm v0.8.2-0.20210802225558-b607bba099c1 h1:vKk+AWqGjiaD9qSsdN1L9qVP8X3pwrqeGBSdRf0/Umk=
 github.com/openservicemesh/osm v0.8.2-0.20210802225558-b607bba099c1/go.mod h1:ABKbMdxIUw9FPISOL0ouw7oH9YptNVLD4PpZ6Y/omgI=
+github.com/openservicemesh/osm v0.8.2-0.20210823171715-5fba2d3f778b h1:iAbEvDoRQgNZjd0v10xU/PJ5HGEwNff3Ggnwq0Vc5kw=
+github.com/openservicemesh/osm v0.8.2-0.20210823171715-5fba2d3f778b/go.mod h1:ABKbMdxIUw9FPISOL0ouw7oH9YptNVLD4PpZ6Y/omgI=
 github.com/openservicemesh/osm v0.9.1 h1:/u5BF2sW6oPka2GLPOyt/ojA8MfKmRmD/tqKVwkimMY=
 github.com/openservicemesh/osm v0.9.1/go.mod h1:r0cPM8bz8j7RD3ZTcycfaWS0rS45sE3nXtgHgRfBb6k=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 h1:lM6RxxfUMrYL/f8bWEUqdXrANWtrL7Nndbm9iFN0DlU=

--- a/pkg/smi/access/routes_validity.go
+++ b/pkg/smi/access/routes_validity.go
@@ -1,0 +1,162 @@
+package access
+
+import (
+	"context"
+	"fmt"
+
+	smiAccessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm-health/pkg/common"
+	"github.com/openservicemesh/osm-health/pkg/common/outcomes"
+	"github.com/openservicemesh/osm-health/pkg/osm"
+	"github.com/openservicemesh/osm-health/pkg/smi"
+	"github.com/openservicemesh/osm-health/pkg/smi/access/v1alpha2"
+	"github.com/openservicemesh/osm-health/pkg/smi/access/v1alpha3"
+	"github.com/openservicemesh/osm/pkg/configurator"
+)
+
+// Verify interface compliance
+var _ common.Runnable = (*RoutesValidityCheck)(nil)
+
+// RoutesValidityCheck implements common.Runnable
+type RoutesValidityCheck struct {
+	osmVersion   osm.ControllerVersion
+	cfg          configurator.Configurator
+	srcPod       *corev1.Pod
+	dstPod       *corev1.Pod
+	accessClient smiAccessClient.Interface
+}
+
+// NewRoutesValidityCheck returns a check of type RoutesValidityCheck which checks whether TrafficTargets matching the src and dest pods have supported routes
+func NewRoutesValidityCheck(osmVersion osm.ControllerVersion, osmConfigurator configurator.Configurator, srcPod *corev1.Pod, dstPod *corev1.Pod, smiAccessClient smiAccessClient.Interface) RoutesValidityCheck {
+	return RoutesValidityCheck{
+		osmVersion:   osmVersion,
+		cfg:          osmConfigurator,
+		srcPod:       srcPod,
+		dstPod:       dstPod,
+		accessClient: smiAccessClient,
+	}
+}
+
+// Description implements common.Runnable
+func (check RoutesValidityCheck) Description() string {
+	return fmt.Sprintf(
+		"Checking whether Traffic Targets in namespace %s with source pod %s and destination pod %s have valid routes (Kind: %s or %s)",
+		check.dstPod.Namespace,
+		check.srcPod.Name,
+		check.dstPod.Name,
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind)
+}
+
+// Run implements common.Runnable
+func (check RoutesValidityCheck) Run() outcomes.Outcome {
+	// Check if permissive mode is enabled, in which case every meshed pod is allowed to communicate with each other
+	if check.cfg.IsPermissiveTrafficPolicyMode() {
+		return outcomes.DiagnosticOutcome{LongDiagnostics: "OSM is in permissive traffic policy modes -- all meshed pods can communicate and SMI access policies are not applicable"}
+	}
+	switch check.osmVersion {
+	case "v0.5", "v0.6":
+		return check.runForV1alpha2()
+	case "v0.7", "v0.8", "v0.9":
+		return check.runForV1alpha3()
+	default:
+		return outcomes.FailedOutcome{Error: fmt.Errorf(
+			"OSM Controller version could not be mapped to a TrafficTarget version. Supported versions are v0.5 through v0.9")}
+	}
+}
+
+func (check RoutesValidityCheck) runForV1alpha2() outcomes.Outcome {
+	trafficTargets, err := check.accessClient.AccessV1alpha2().TrafficTargets(check.dstPod.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Err(err).Msgf("Error getting TrafficTargets for namespace %s", check.dstPod.Namespace)
+		return outcomes.FailedOutcome{Error: err}
+	}
+	unsupportedRouteTargets := map[string]string{}
+	var foundMatchingTarget bool
+	for _, trafficTarget := range trafficTargets.Items {
+		spec := trafficTarget.Spec
+		if !v1alpha2.DoesTargetMatchPods(spec, check.srcPod, check.dstPod) {
+			continue
+		}
+		foundMatchingTarget = true
+		for _, rule := range spec.Rules {
+			kind := rule.Kind
+			// TODO: update if supported routes change for the OSM controller
+			if !(kind == smi.HTTPRouteGroupKind || kind == smi.TCPRouteKind) {
+				unsupportedRouteTargets[trafficTarget.Name] = kind
+			}
+		}
+	}
+	if !foundMatchingTarget {
+		return outcomes.DiagnosticOutcome{LongDiagnostics: fmt.Sprintf(
+			"No applicable Traffic Targets in namespace %s to check routes for",
+			check.dstPod.Namespace)}
+	}
+	if len(unsupportedRouteTargets) > 0 {
+		errorString := check.newErrorMessage(unsupportedRouteTargets)
+		return outcomes.FailedOutcome{Error: fmt.Errorf(errorString)}
+	}
+	return outcomes.SuccessfulOutcomeWithoutDiagnostics{}
+}
+
+func (check RoutesValidityCheck) runForV1alpha3() outcomes.Outcome {
+	trafficTargets, err := check.accessClient.AccessV1alpha3().TrafficTargets(check.dstPod.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Err(err).Msgf("Error getting TrafficTargets for namespace %s", check.dstPod.Namespace)
+		return outcomes.FailedOutcome{Error: err}
+	}
+	unsupportedRouteTargets := map[string]string{}
+	var foundMatchingTarget bool
+	for _, trafficTarget := range trafficTargets.Items {
+		spec := trafficTarget.Spec
+		if !v1alpha3.DoesTargetMatchPods(spec, check.srcPod, check.dstPod) {
+			continue
+		}
+		foundMatchingTarget = true
+		for _, rule := range spec.Rules {
+			kind := rule.Kind
+			// TODO: update if supported routes change for the OSM controller
+			if !(kind == smi.HTTPRouteGroupKind || kind == smi.TCPRouteKind) {
+				unsupportedRouteTargets[trafficTarget.Name] = kind
+			}
+		}
+	}
+	if !foundMatchingTarget {
+		return outcomes.DiagnosticOutcome{LongDiagnostics: fmt.Sprintf(
+			"No applicable Traffic Targets in namespace %s to check routes for",
+			check.dstPod.Namespace)}
+	}
+	if len(unsupportedRouteTargets) > 0 {
+		errorString := check.newErrorMessage(unsupportedRouteTargets)
+		return outcomes.FailedOutcome{Error: fmt.Errorf(errorString)}
+	}
+	return outcomes.SuccessfulOutcomeWithoutDiagnostics{}
+}
+
+func (*RoutesValidityCheck) newErrorMessage(targetToKindMap map[string]string) string {
+	errorString := fmt.Sprintf(
+		"Expected routes of kind %s or %s, found the following TrafficTargets with unsupported routes: \n",
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind)
+	for target, kind := range targetToKindMap {
+		errorString = fmt.Sprintf("%s %s: %s\n", errorString, target, kind)
+	}
+	return errorString
+}
+
+// Suggestion implements common.Runnable
+func (check RoutesValidityCheck) Suggestion() string {
+	return fmt.Sprintf(
+		"Check that TrafficTargets routes are of kind %s or %s. To get relevant TrafficTargets, use: \"kubectl get traffictarget -n %s -o yaml\"",
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind,
+		check.dstPod.Namespace)
+}
+
+// FixIt implements common.Runnable
+func (check RoutesValidityCheck) FixIt() error {
+	panic("implement me")
+}

--- a/pkg/smi/access/traffic_target.go
+++ b/pkg/smi/access/traffic_target.go
@@ -1,0 +1,138 @@
+package access
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	smiAccessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm-health/pkg/common"
+	"github.com/openservicemesh/osm-health/pkg/common/outcomes"
+	"github.com/openservicemesh/osm-health/pkg/osm"
+	"github.com/openservicemesh/osm-health/pkg/smi/access/v1alpha2"
+	"github.com/openservicemesh/osm-health/pkg/smi/access/v1alpha3"
+	"github.com/openservicemesh/osm/pkg/configurator"
+)
+
+// Verify interface compliance
+var _ common.Runnable = (*TrafficTargetCheck)(nil)
+
+// TrafficTargetCheck implements common.Runnable
+type TrafficTargetCheck struct {
+	osmVersion   osm.ControllerVersion
+	cfg          configurator.Configurator
+	srcPod       *corev1.Pod
+	dstPod       *corev1.Pod
+	accessClient smiAccessClient.Interface
+}
+
+// NewTrafficTargetCheck creates a check of type TrafficTargetCheck which checks whether the src and dest pods are referenced as src and dest in a TrafficTarget (in that order)
+func NewTrafficTargetCheck(osmVersion osm.ControllerVersion, osmConfigurator configurator.Configurator, srcPod *corev1.Pod, dstPod *corev1.Pod, smiAccessClient smiAccessClient.Interface) TrafficTargetCheck {
+	return TrafficTargetCheck{
+		osmVersion:   osmVersion,
+		cfg:          osmConfigurator,
+		srcPod:       srcPod,
+		dstPod:       dstPod,
+		accessClient: smiAccessClient,
+	}
+}
+
+// Description implements common.Runnable
+func (check TrafficTargetCheck) Description() string {
+	return fmt.Sprintf(
+		"Checking whether there is a Traffic Target with source pod %s and destination pod %s in namespace %s",
+		check.srcPod.Name,
+		check.dstPod.Name,
+		check.dstPod.Namespace)
+}
+
+// Run implements common.Runnable
+func (check TrafficTargetCheck) Run() outcomes.Outcome {
+	// Check if permissive mode is enabled, in which case every meshed pod is allowed to communicate with each other
+	if check.cfg.IsPermissiveTrafficPolicyMode() {
+		return outcomes.DiagnosticOutcome{LongDiagnostics: "OSM is in permissive traffic policy modes -- all meshed pods can communicate and SMI access policies are not applicable"}
+	}
+	switch check.osmVersion {
+	case "v0.5", "v0.6":
+		return check.runForV1alpha2()
+	case "v0.7", "v0.8", "v0.9":
+		return check.runForV1alpha3()
+	default:
+		return outcomes.FailedOutcome{Error: fmt.Errorf(
+			"OSM Controller version could not be mapped to a TrafficTarget version. Supported versions are v0.5 through v0.9")}
+	}
+}
+
+func (check TrafficTargetCheck) runForV1alpha2() outcomes.Outcome {
+	trafficTargets, err := check.accessClient.AccessV1alpha2().TrafficTargets(check.dstPod.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Err(err).Msgf("Error getting TrafficTargets for namespace %s", check.dstPod.Namespace)
+		return outcomes.FailedOutcome{Error: err}
+	}
+	var matchingTargetNames []string
+	for _, trafficTarget := range trafficTargets.Items {
+		if v1alpha2.DoesTargetMatchPods(trafficTarget.Spec, check.srcPod, check.dstPod) {
+			matchingTargetNames = append(matchingTargetNames, trafficTarget.Name)
+		}
+	}
+	if len(matchingTargetNames) > 0 {
+		return outcomes.DiagnosticOutcome{LongDiagnostics: fmt.Sprintf(
+			"Pod '%s/%s' is allowed to communicate to pod '%s/%s' via SMI TrafficTarget policy/policies %s\n",
+			check.srcPod.Namespace,
+			check.srcPod.Name,
+			check.dstPod.Namespace,
+			check.dstPod.Name,
+			strings.Join(matchingTargetNames, ", ")),
+		}
+	}
+	return outcomes.DiagnosticOutcome{LongDiagnostics: fmt.Sprintf(
+		"Pod '%s/%s' is not allowed to communicate to pod '%s/%s' via any SMI TrafficTarget policy\n",
+		check.srcPod.Namespace,
+		check.srcPod.Name,
+		check.dstPod.Namespace,
+		check.dstPod.Name)}
+}
+
+func (check TrafficTargetCheck) runForV1alpha3() outcomes.Outcome {
+	trafficTargets, err := check.accessClient.AccessV1alpha3().TrafficTargets(check.dstPod.Namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Err(err).Msgf("Error getting TrafficTargets for namespace %s", check.dstPod.Namespace)
+		return outcomes.FailedOutcome{Error: err}
+	}
+	var matchingTargetNames []string
+	for _, trafficTarget := range trafficTargets.Items {
+		if v1alpha3.DoesTargetMatchPods(trafficTarget.Spec, check.srcPod, check.dstPod) {
+			matchingTargetNames = append(matchingTargetNames, trafficTarget.Name)
+		}
+	}
+	if len(matchingTargetNames) > 0 {
+		return outcomes.DiagnosticOutcome{LongDiagnostics: fmt.Sprintf(
+			"Pod '%s/%s' is allowed to communicate to pod '%s/%s' via SMI TrafficTarget policy/policies %s\n",
+			check.srcPod.Namespace,
+			check.srcPod.Name,
+			check.dstPod.Namespace,
+			check.dstPod.Name,
+			strings.Join(matchingTargetNames, ", "))}
+	}
+	return outcomes.DiagnosticOutcome{LongDiagnostics: fmt.Sprintf(
+		"Pod '%s/%s' is not allowed to communicate to pod '%s/%s' via any SMI TrafficTarget policy\n",
+		check.srcPod.Namespace,
+		check.srcPod.Name,
+		check.dstPod.Namespace,
+		check.dstPod.Name)}
+}
+
+// Suggestion implements common.Runnable
+func (check TrafficTargetCheck) Suggestion() string {
+	return fmt.Sprintf(
+		"Check that source and desintation pod are referred to in a TrafficTarget. To get relevant TrafficTargets, use: \"kubectl get traffictarget -n %s -o yaml\"",
+		check.dstPod.Namespace)
+}
+
+// FixIt implements common.Runnable
+func (check TrafficTargetCheck) FixIt() error {
+	panic("implement me")
+}

--- a/pkg/smi/access/types.go
+++ b/pkg/smi/access/types.go
@@ -1,0 +1,5 @@
+package access
+
+import "github.com/openservicemesh/osm-health/pkg/logger"
+
+var log = logger.New("osm-health/access")

--- a/pkg/smi/access/v1alpha2/methods.go
+++ b/pkg/smi/access/v1alpha2/methods.go
@@ -1,0 +1,36 @@
+package v1alpha2
+
+import (
+	accessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	serviceAccountKind = "ServiceAccount"
+)
+
+// DoesTargetMatchPods checks whether a given TrafficTarget has dstPod as its destination as dstPod and srcPod as an allowed source to this destination
+func DoesTargetMatchPods(spec accessClient.TrafficTargetSpec, srcPod *corev1.Pod, dstPod *corev1.Pod) bool {
+	return doesTargetRefDstPod(spec, dstPod) && doesTargetRefSrcPod(spec, srcPod)
+}
+
+// doesTargetRefDstPod checks whether the TrafficTarget spec refers to the destination pod's service account
+func doesTargetRefDstPod(spec accessClient.TrafficTargetSpec, dstPod *corev1.Pod) bool {
+	if spec.Destination.Kind != serviceAccountKind {
+		return false
+	}
+	return spec.Destination.Name == dstPod.Spec.ServiceAccountName && spec.Destination.Namespace == dstPod.Namespace
+}
+
+// doesTargetRefSrcPod checks whether the TrafficTarget spec refers to the source pod's service account
+func doesTargetRefSrcPod(spec accessClient.TrafficTargetSpec, srcPod *corev1.Pod) bool {
+	for _, source := range spec.Sources {
+		if source.Kind != serviceAccountKind {
+			continue
+		}
+		if source.Name == srcPod.Spec.ServiceAccountName && source.Namespace == srcPod.Namespace {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/smi/access/v1alpha3/methods.go
+++ b/pkg/smi/access/v1alpha3/methods.go
@@ -1,0 +1,13 @@
+package v1alpha3
+
+import (
+	accessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm/pkg/cli"
+)
+
+// DoesTargetMatchPods checks whether a given TrafficTarget has dstPod as its destination as dstPod and srcPod as an allowed source to this destination
+func DoesTargetMatchPods(spec accessClient.TrafficTargetSpec, srcPod *corev1.Pod, dstPod *corev1.Pod) bool {
+	return cli.DoesTargetRefDstPod(spec, dstPod) && cli.DoesTargetRefSrcPod(spec, srcPod)
+}

--- a/pkg/smi/constants.go
+++ b/pkg/smi/constants.go
@@ -1,0 +1,9 @@
+package smi
+
+const (
+	// HTTPRouteGroupKind is the Kind for HTTPRouteGroup
+	HTTPRouteGroupKind = "HTTPRouteGroup"
+
+	// TCPRouteKind is the Kind for TCPRoute
+	TCPRouteKind = "TCPRoute"
+)


### PR DESCRIPTION
- diagnostic check for existence of traffic targets
- pass/fail check for route validity - ideally this check should only be carried out if the previous one passes but for now we don't have the right logic for that (ref #73)
- added packages to be able to version smi access client based on osm controller version