### PR TITLE
feat(envoy/sds): check envoy certificates

### DIFF
--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -97,6 +97,12 @@ func PodToPod(fromPod *corev1.Pod, toPod *corev1.Pod, osmControlPlaneNamespace s
 		// Source Envoy must define a cluster for the destination
 		envoy.HasCluster(client, srcConfigGetter, toPod),
 
+		// Check Envoy certificates for both pods
+		envoy.HasOutboundRootCertificate(client, srcConfigGetter, toPod),
+		envoy.HasInboundRootCertificate(client, dstConfigGetter, toPod),
+		envoy.HasServiceCertificate(client, srcConfigGetter, fromPod),
+		envoy.HasServiceCertificate(client, dstConfigGetter, toPod),
+
 		// Run SMI checks
 		smi.IsInTrafficSplit(client, toPod, splitClient),
 	)

--- a/pkg/envoy/sds.go
+++ b/pkg/envoy/sds.go
@@ -1,0 +1,158 @@
+package envoy
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm-health/pkg/common"
+	"github.com/openservicemesh/osm-health/pkg/common/outcomes"
+	"github.com/openservicemesh/osm-health/pkg/kuberneteshelper"
+	"github.com/openservicemesh/osm/pkg/utils"
+)
+
+// Verify interface compliance
+var _ common.Runnable = (*HasValidEnvoyCertificateCheck)(nil)
+
+// HasValidEnvoyCertificateCheck implements common.Runnable
+type HasValidEnvoyCertificateCheck struct {
+	ConfigGetter
+	pod             *corev1.Pod
+	k8s             kubernetes.Interface
+	certificateType SDSCertType
+}
+
+// SDSCertType is a type of a certificate requested by an Envoy proxy via SDS.
+type SDSCertType string
+
+const (
+	// ServiceCertType is the prefix for the service certificate resource name.
+	// Example: "service-cert:<service namespace>/<service service account>"
+	ServiceCertType SDSCertType = "service-cert"
+
+	// RootCertTypeForMTLSOutbound is the prefix for the mTLS root certificate
+	// resource name for upstream connectivity.
+	// Example: "root-cert-for-mtls-outbound:<service namespace>/<service name>"
+	RootCertTypeForMTLSOutbound SDSCertType = "root-cert-for-mtls-outbound"
+
+	// RootCertTypeForMTLSInbound is the prefix for the mTLS root certificate
+	// resource name for downstream connectivity.
+	// Example: "root-cert-for-mtls-inbound:<service namespace>/<service service account>"
+	RootCertTypeForMTLSInbound SDSCertType = "root-cert-for-mtls-inbound"
+)
+
+func (ct SDSCertType) String() string {
+	return string(ct)
+}
+
+// Run implements common.Runnable
+func (c HasValidEnvoyCertificateCheck) Run() outcomes.Outcome {
+	if c.ConfigGetter == nil {
+		log.Error().Msg("Incorrectly initialized ConfigGetter")
+		return outcomes.FailedOutcome{Error: ErrIncorrectlyInitializedConfigGetter}
+	}
+	envoyConfig, err := c.ConfigGetter.GetConfig()
+	if err != nil {
+		return outcomes.FailedOutcome{Error: err}
+	}
+
+	if envoyConfig == nil {
+		return outcomes.FailedOutcome{Error: ErrEnvoyConfigEmpty}
+	}
+
+	// Checks if a secret of the specified certificate type exists in the
+	// provided Envoy config with a name derived from the given Pod.
+	// Secret name formats for each certificate type:
+	// - root-cert-for-mtls-outbound:<service namespace>/<service name>
+	// - root-cert-for-mtls-inbound:<service namespace>/<service service account>
+	// - service-cert:<service namespace>/<service service account>
+	//
+	// The secret name for an outbound mTLS root certificate is formatted using
+	// the destination Pod's service name. The Pod might back multiple services,
+	// so construct the secret name for each possible service.
+	possibleSecretNames := map[string]struct{}{}
+	if c.certificateType == RootCertTypeForMTLSOutbound {
+		svcs, err := kuberneteshelper.GetMatchingServices(c.k8s, c.pod.Labels, c.pod.Namespace)
+		if err != nil {
+			return outcomes.FailedOutcome{Error: errors.Wrapf(err, "failed to map Pod %s/%s to Kubernetes Services", c.pod.Namespace, c.pod.Name)}
+		}
+		for _, svc := range svcs {
+			possibleSecretNames[fmt.Sprintf("%s:%s", c.certificateType.String(), utils.K8sSvcToMeshSvc(svc).String())] = struct{}{}
+		}
+	} else {
+		possibleSecretNames[fmt.Sprintf("%s:%s/%s", c.certificateType.String(), c.pod.Namespace, c.pod.Spec.ServiceAccountName)] = struct{}{}
+	}
+
+	if len(possibleSecretNames) == 0 {
+		return outcomes.FailedOutcome{Error: fmt.Errorf("no secrets listed in the Envoy config")}
+	}
+
+	// Check that at least one of the possible secret names is in the
+	// Envoy config
+	found := false
+	var foundSecretNames []string
+	for _, dynSecret := range envoyConfig.SecretsConfigDump.GetDynamicActiveSecrets() {
+		foundSecretNames = append(foundSecretNames, dynSecret.Name)
+		if _, exists := possibleSecretNames[dynSecret.Name]; exists {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return outcomes.FailedOutcome{Error: fmt.Errorf("expected a secret named one of %v, but only found %v", possibleSecretNames, foundSecretNames)}
+	}
+
+	return outcomes.SuccessfulOutcomeWithoutDiagnostics{}
+}
+
+// Suggestion implements common.Runnable
+func (c HasValidEnvoyCertificateCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (c HasValidEnvoyCertificateCheck) FixIt() error {
+	panic("implement me")
+}
+
+// Description implements common.Runnable
+func (c HasValidEnvoyCertificateCheck) Description() string {
+	return fmt.Sprintf("Checking whether %s is configured with a %s envoy secret", c.ConfigGetter.GetObjectName(), c.certificateType)
+}
+
+// HasInboundRootCertificate creates a new common.Runnable, which checks whether the given Pod
+// has an Envoy with a properly configured inbound root validation certificate.
+func HasInboundRootCertificate(client kubernetes.Interface, dstConfigGetter ConfigGetter, dst *corev1.Pod) common.Runnable {
+	return HasValidEnvoyCertificateCheck{
+		ConfigGetter:    dstConfigGetter,
+		k8s:             client,
+		pod:             dst,
+		certificateType: RootCertTypeForMTLSInbound,
+	}
+}
+
+// HasOutboundRootCertificate creates a new common.Runnable, which checks whether the source Pod
+// has an Envoy with a properly configured outbound root validation certificate for the given
+// destination Pod.
+func HasOutboundRootCertificate(client kubernetes.Interface, srcConfigGetter ConfigGetter, dst *corev1.Pod) common.Runnable {
+	return HasValidEnvoyCertificateCheck{
+		ConfigGetter:    srcConfigGetter,
+		k8s:             client,
+		pod:             dst,
+		certificateType: RootCertTypeForMTLSOutbound,
+	}
+}
+
+// HasServiceCertificate creates a new common.Runnable, which checks whether the given Pod
+// has an Envoy with a properly configured service certificate.
+func HasServiceCertificate(client kubernetes.Interface, configGetter ConfigGetter, pod *corev1.Pod) common.Runnable {
+	return HasValidEnvoyCertificateCheck{
+		ConfigGetter:    configGetter,
+		k8s:             client,
+		pod:             pod,
+		certificateType: ServiceCertType,
+	}
+}

--- a/pkg/envoy/sds_test.go
+++ b/pkg/envoy/sds_test.go
@@ -1,0 +1,362 @@
+package envoy
+
+import (
+	"fmt"
+	"testing"
+
+	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	tassert "github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm-health/pkg/common"
+)
+
+func TestEnvoySecretCheck(t *testing.T) {
+	tests := []struct {
+		name      string
+		checkFunc func(kubernetes.Interface, ConfigGetter, *corev1.Pod) common.Runnable
+		config    *Config
+		dstPod    *corev1.Pod
+		svcs      []*corev1.Service
+		svcAccts  []*corev1.ServiceAccount
+		pass      bool
+	}{
+		{
+			name:      "pod matches one service with outbound mTLS root certificate secret in config",
+			checkFunc: HasOutboundRootCertificate,
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicActiveSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{
+						{
+							Name: fmt.Sprintf("%s:%s", RootCertTypeForMTLSOutbound, "mynamespace/myservice"),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+			},
+			svcs: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myservice",
+						Namespace: "mynamespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"mykey": "myval",
+						},
+					},
+				},
+			},
+			svcAccts: nil,
+			pass:     true,
+		},
+		{
+			name:      "pod matches one service without outbound mTLS root certificate secret in config",
+			checkFunc: HasOutboundRootCertificate,
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicActiveSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{
+						{
+							Name: fmt.Sprintf("%s:%s", RootCertTypeForMTLSOutbound, "mynamespace/not-myservice"),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+			},
+			svcs: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myservice",
+						Namespace: "mynamespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"mykey": "myval",
+						},
+					},
+				},
+			},
+			svcAccts: nil,
+			pass:     false,
+		},
+		{
+			name:      "pod matches two services with one outbound mTLS root certificate secret in config",
+			checkFunc: HasOutboundRootCertificate,
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicActiveSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{
+						{
+							Name: fmt.Sprintf("%s:%s", RootCertTypeForMTLSOutbound, "mynamespace/myservice"),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+			},
+			svcs: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myservice",
+						Namespace: "mynamespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"mykey": "myval",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myservice2",
+						Namespace: "mynamespace",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"mykey": "myval",
+						},
+					},
+				},
+			},
+			svcAccts: nil,
+			pass:     true,
+		},
+		{
+			name:      "pod matches no services with no outbound mTLS root certificate secrets",
+			checkFunc: HasOutboundRootCertificate,
+			config:    &Config{},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+				},
+			},
+			svcs:     nil,
+			svcAccts: nil,
+			pass:     false,
+		},
+		{
+			name:      "pod has serviceaccount and inbound mTLS root certificate secret in config",
+			checkFunc: HasInboundRootCertificate,
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicActiveSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{
+						{
+							Name: fmt.Sprintf("%s:%s", RootCertTypeForMTLSInbound, "mynamespace/myserviceaccount"),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "myserviceaccount",
+				},
+			},
+			svcs: nil,
+			svcAccts: []*corev1.ServiceAccount{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myserviceaccount",
+						Namespace: "mynamespace",
+					},
+				},
+			},
+			pass: true,
+		},
+		{
+			name:      "pod has serviceaccount and no inbound mTLS root certificate secret in config",
+			checkFunc: HasInboundRootCertificate,
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicActiveSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{
+						{
+							Name: fmt.Sprintf("%s:%s", RootCertTypeForMTLSInbound, "mynamespace/not-myserviceaccount"),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "myserviceaccount",
+				},
+			},
+			svcs: nil,
+			svcAccts: []*corev1.ServiceAccount{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myserviceaccount",
+						Namespace: "mynamespace",
+					},
+				},
+			},
+			pass: false,
+		},
+		{
+			name:      "pod has serviceaccount and no inbound mTLS root certificate secrets in config",
+			checkFunc: HasInboundRootCertificate,
+			config:    &Config{},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "myserviceaccount",
+				},
+			},
+			svcs: nil,
+			svcAccts: []*corev1.ServiceAccount{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myserviceaccount",
+						Namespace: "mynamespace",
+					},
+				},
+			},
+			pass: false,
+		},
+		{
+			name:      "pod has no serviceaccount and no inbound mTLS root certificate secret in config",
+			checkFunc: HasInboundRootCertificate,
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicActiveSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{
+						{
+							Name: fmt.Sprintf("%s:%s", RootCertTypeForMTLSInbound, "mynamespace/not-myserviceaccount"),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+			},
+			svcs:     nil,
+			svcAccts: nil,
+			pass:     false,
+		},
+		{
+			name:      "pod has serviceaccount and service certificate secret in config",
+			checkFunc: HasServiceCertificate,
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicActiveSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{
+						{
+							Name: fmt.Sprintf("%s:%s", ServiceCertType, "mynamespace/myserviceaccount"),
+						},
+					},
+				},
+			},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "myserviceaccount",
+				},
+			},
+			svcs: nil,
+			svcAccts: []*corev1.ServiceAccount{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myserviceaccount",
+						Namespace: "mynamespace",
+					},
+				},
+			},
+			pass: true,
+		},
+		{
+			name:      "pod has no serviceaccount and no service certificate secret in config",
+			checkFunc: HasServiceCertificate,
+			config:    &Config{},
+			dstPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mypod",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"mykey": "myval",
+					},
+				},
+			},
+			svcs:     nil,
+			svcAccts: nil,
+			pass:     false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			configGetter := mockConfigGetter{
+				getter: func() (*Config, error) {
+					return test.config, nil
+				},
+			}
+			objs := make([]runtime.Object, len(test.svcs))
+			for i := range test.svcs {
+				objs[i] = test.svcs[i]
+			}
+			k8s := fake.NewSimpleClientset(objs...)
+			envoyCertificateChecker := test.checkFunc(k8s, configGetter, test.dstPod)
+			outcome := envoyCertificateChecker.Run()
+			if test.pass {
+				assert.NoError(outcome.GetError())
+			} else {
+				assert.Error(outcome.GetError())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a check to the pop-to-pod connectivity check to verify the
presence of service certificates for the src and dst, the outbound
mTLS root certificate in the src's envoy config, and the inbound
mTLS root certificate in the dst's envoy config.

Signed-off-by: jaellio <jaellio@microsoft.com>