### PR TITLE
fix(rds): check for service names, not pod name

### DIFF
--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -90,10 +90,10 @@ func PodToPod(fromPod *corev1.Pod, toPod *corev1.Pod, osmControlPlaneNamespace s
 		envoy.NewSpecificEndpointCheck(srcConfigGetter, toPod),
 
 		// Check whether the source Pod has an outbound dynamic route config domain that matches the destination Pod.
-		envoy.NewOutboundRouteDomainPodCheck(srcConfigGetter, toPod),
+		envoy.NewOutboundRouteDomainPodCheck(client, srcConfigGetter, toPod),
 
-		// Check whether the destination Pod has an inbound dynamic route config domain that matches the source Pod.
-		envoy.NewInboundRouteDomainPodCheck(dstConfigGetter, fromPod),
+		// Check whether the destination Pod has an inbound dynamic route config domain that matches the destination Pod.
+		envoy.NewInboundRouteDomainPodCheck(client, dstConfigGetter, toPod),
 
 		// Source Envoy must have Outbound listener
 		envoy.NewOutboundListenerCheck(srcConfigGetter, osmVersion),

--- a/pkg/envoy/errors.go
+++ b/pkg/envoy/errors.go
@@ -32,4 +32,7 @@ var (
 
 	// ErrDynamicRouteConfigDomainNotFound is an error returned when a specific dynamic route config domain is not found.
 	ErrDynamicRouteConfigDomainNotFound = errors.New("dynamic route config domain not found")
+
+	// ErrNoAssociatedDomains is an error returned when a destination is not associated with any domains and therefore is unroutable.
+	ErrNoAssociatedDomains = errors.New("no associated domains that can be routed to the destination")
 )

--- a/pkg/envoy/rds.go
+++ b/pkg/envoy/rds.go
@@ -57,6 +57,10 @@ func (l RouteDomainCheck) Run() outcomes.Outcome {
 		}
 	}
 
+	if len(possibleDomains) == 0 {
+		return outcomes.FailedOutcome{Error: ErrNoAssociatedDomains}
+	}
+
 	for _, rawDynRouteCfg := range envoyConfig.Routes.GetDynamicRouteConfigs() {
 		var dynRouteCfg envoy_config_route_v3.RouteConfiguration
 		if err = rawDynRouteCfg.GetRouteConfig().UnmarshalTo(&dynRouteCfg); err != nil {

--- a/pkg/envoy/rds_test.go
+++ b/pkg/envoy/rds_test.go
@@ -20,7 +20,6 @@ func TestEnvoyOutboundRouteDomainPodChecker(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 			Labels: map[string]string{
 				"bookstore": "yes",
@@ -53,7 +52,6 @@ func TestEnvoyOutboundRouteDomainPodCheckerEmptyConfig(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 		},
 	}
@@ -70,7 +68,6 @@ func TestEnvoyOutboundRouteDomainPodCheckerNoDomains(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 		},
 	}
@@ -87,7 +84,6 @@ func TestEnvoyOutboundRouteDomainPodCheckerDomainNotFound(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 			Labels: map[string]string{
 				"bookstore": "yes",
@@ -119,7 +115,6 @@ func TestEnvoyInboundRouteDomainPodChecker(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 			Labels: map[string]string{
 				"bookstore": "yes",
@@ -152,7 +147,6 @@ func TestEnvoyInboundRouteDomainPodCheckerEmptyConfig(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 		},
 	}
@@ -169,7 +163,6 @@ func TestEnvoyInboundRouteDomainPodCheckerNoDomains(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 		},
 	}
@@ -186,7 +179,6 @@ func TestEnvoyInboundRouteDomainPodCheckerDomainNotFound(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 			Labels: map[string]string{
 				"bookstore": "yes",

--- a/pkg/envoy/rds_test.go
+++ b/pkg/envoy/rds_test.go
@@ -6,6 +6,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 var (
@@ -19,11 +20,26 @@ func TestEnvoyOutboundRouteDomainPodChecker(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
+			Namespace: "bookstore",
+			Labels: map[string]string{
+				"bookstore": "yes",
+			},
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bookstore",
 			Namespace: "bookstore",
 		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"bookstore": "yes",
+			},
+		},
 	}
-	routeDomainChecker := NewOutboundRouteDomainPodCheck(configGetter, pod)
+	client := fake.NewSimpleClientset(svc)
+	routeDomainChecker := NewOutboundRouteDomainPodCheck(client, configGetter, pod)
 	outcome := routeDomainChecker.Run()
 	assert.Nil(outcome.GetError())
 }
@@ -37,11 +53,11 @@ func TestEnvoyOutboundRouteDomainPodCheckerEmptyConfig(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore",
+			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 		},
 	}
-	routeDomainChecker := NewOutboundRouteDomainPodCheck(configGetter, pod)
+	routeDomainChecker := NewOutboundRouteDomainPodCheck(nil, configGetter, pod)
 	outcome := routeDomainChecker.Run()
 	assert.NotNil(outcome.GetError())
 	assert.Equal("envoy config is empty", outcome.GetError().Error())
@@ -54,11 +70,11 @@ func TestEnvoyOutboundRouteDomainPodCheckerNoDomains(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore",
+			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 		},
 	}
-	routeDomainChecker := NewOutboundRouteDomainPodCheck(configGetter, pod)
+	routeDomainChecker := NewOutboundRouteDomainPodCheck(nil, configGetter, pod)
 	outcome := routeDomainChecker.Run()
 	assert.NotNil(outcome.GetError())
 	assert.Equal("no dynamic route config domains", outcome.GetError().Error())
@@ -71,11 +87,26 @@ func TestEnvoyOutboundRouteDomainPodCheckerDomainNotFound(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
+			Namespace: "bookstore",
+			Labels: map[string]string{
+				"bookstore": "yes",
+			},
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bookstore",
 			Namespace: "bookstore",
 		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"bookstore": "yes",
+			},
+		},
 	}
-	routeDomainChecker := NewOutboundRouteDomainPodCheck(configGetter, pod)
+	client := fake.NewSimpleClientset(svc)
+	routeDomainChecker := NewOutboundRouteDomainPodCheck(client, configGetter, pod)
 	outcome := routeDomainChecker.Run()
 	assert.NotNil(outcome.GetError())
 	assert.Equal("dynamic route config domain not found", outcome.GetError().Error())
@@ -88,11 +119,26 @@ func TestEnvoyInboundRouteDomainPodChecker(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1",
+			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
+			Labels: map[string]string{
+				"bookstore": "yes",
+			},
 		},
 	}
-	routeDomainChecker := NewInboundRouteDomainPodCheck(configGetter, pod)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bookstore",
+			Namespace: "bookstore",
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"bookstore": "yes",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(svc)
+	routeDomainChecker := NewInboundRouteDomainPodCheck(client, configGetter, pod)
 	outcome := routeDomainChecker.Run()
 	assert.Nil(outcome.GetError())
 }
@@ -106,11 +152,11 @@ func TestEnvoyInboundRouteDomainPodCheckerEmptyConfig(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1",
+			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 		},
 	}
-	routeDomainChecker := NewInboundRouteDomainPodCheck(configGetter, pod)
+	routeDomainChecker := NewInboundRouteDomainPodCheck(nil, configGetter, pod)
 	outcome := routeDomainChecker.Run()
 	assert.NotNil(outcome.GetError())
 	assert.Equal("envoy config is empty", outcome.GetError().Error())
@@ -123,11 +169,11 @@ func TestEnvoyInboundRouteDomainPodCheckerNoDomains(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1",
+			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
 		},
 	}
-	routeDomainChecker := NewInboundRouteDomainPodCheck(configGetter, pod)
+	routeDomainChecker := NewInboundRouteDomainPodCheck(nil, configGetter, pod)
 	outcome := routeDomainChecker.Run()
 	assert.NotNil(outcome.GetError())
 	assert.Equal("no dynamic route config domains", outcome.GetError().Error())
@@ -140,11 +186,26 @@ func TestEnvoyInboundRouteDomainPodCheckerDomainNotFound(t *testing.T) {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bookstore-v1",
+			Name:      "bookstore-v1-74d9cbd7c8-dlmlj",
 			Namespace: "bookstore",
+			Labels: map[string]string{
+				"bookstore": "yes",
+			},
 		},
 	}
-	routeDomainChecker := NewInboundRouteDomainPodCheck(configGetter, pod)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bookstore",
+			Namespace: "bookstore",
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"bookstore": "yes",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(svc)
+	routeDomainChecker := NewInboundRouteDomainPodCheck(client, configGetter, pod)
 	outcome := routeDomainChecker.Run()
 	assert.NotNil(outcome.GetError())
 	assert.Equal("dynamic route config domain not found", outcome.GetError().Error())


### PR DESCRIPTION
This change modifies `NewOutboundRouteDomainPodCheck` and
`NewInboundRouteDomainPodCheck` to check for domains in the virtual
hosts of the RDS configs matching the service(s) backed by the
destination pod instead of the pod name.

Fixes #76