### PR TITLE
fix(events): limit to one pod

### DIFF
--- a/pkg/kubernetes/podhelper/events.go
+++ b/pkg/kubernetes/podhelper/events.go
@@ -39,7 +39,7 @@ func (check PodEventsCheck) Run() outcomes.Outcome {
 	eventsInterface := check.client.CoreV1().Events(check.pod.Namespace)
 	var events *corev1.EventList
 
-	selectorString := "type!=Normal"
+	selectorString := "type!=Normal,involvedObject.apiVersion=v1,involvedObject.kind=Pod,involvedObject.name=" + check.pod.Name
 	options := metav1.ListOptions{FieldSelector: selectorString}
 	events, err := eventsInterface.List(context.TODO(), options)
 	if err != nil {


### PR DESCRIPTION
Currently, the check for Kubernetes events lists all events in the
namespace. This change filters out all events except those for the
specified pod.