### PR TITLE
feat(connectivity): check destination pod is in an Endpoint

### DIFF
--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -75,6 +75,8 @@ func PodToPod(fromPod *corev1.Pod, toPod *corev1.Pod, osmControlPlaneNamespace s
 		podhelper.NewProxyUUIDLabelCheck(fromPod),
 		podhelper.NewProxyUUIDLabelCheck(toPod),
 
+		podhelper.NewEndpointsCheck(client, toPod),
+
 		// Check pods for bad events
 		podhelper.NewPodEventsCheck(client, fromPod),
 		podhelper.NewPodEventsCheck(client, toPod),

--- a/pkg/kubernetes/podhelper/endpoints.go
+++ b/pkg/kubernetes/podhelper/endpoints.go
@@ -1,0 +1,73 @@
+package podhelper
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm-health/pkg/common/outcomes"
+)
+
+// EndpointsCheck implements common.Runnable
+type EndpointsCheck struct {
+	client kubernetes.Interface
+	pod    *corev1.Pod
+}
+
+// NewEndpointsCheck creates an EndpointsCheck which checks whether a pod is
+// referenced by a Kubernetes Endpoints resource.
+func NewEndpointsCheck(client kubernetes.Interface, pod *corev1.Pod) EndpointsCheck {
+	return EndpointsCheck{
+		client: client,
+		pod:    pod,
+	}
+}
+
+// Description implements common.Runnable
+func (e EndpointsCheck) Description() string {
+	return fmt.Sprintf("Checking whether pod %s/%s is referenced by a Kubernetes Endpoints resource", e.pod.Namespace, e.pod.Name)
+}
+
+// Run implements common.Runnable
+func (e EndpointsCheck) Run() outcomes.Outcome {
+	eps, err := e.client.CoreV1().Endpoints(e.pod.Namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return outcomes.FailedOutcome{Error: err}
+	}
+
+	found := false
+	for _, ep := range eps.Items {
+		for _, subset := range ep.Subsets {
+			for _, addr := range subset.Addresses {
+				if addr.TargetRef.Name == e.pod.Name {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+
+	if !found {
+		return outcomes.FailedOutcome{Error: ErrPodNotInEndpoints}
+	}
+	return outcomes.SuccessfulOutcomeWithoutDiagnostics{}
+}
+
+// Suggestion implements common.Runnable
+func (e EndpointsCheck) Suggestion() string {
+	return fmt.Sprintf("Verify the selector on the Kubernetes Service in the %s namespace (kubectl get svc -n %s <name> -o jsonpath='{.spec.selector}') that should be backed by Pod %s matches the Pod's labels (kubectl get pod -n %s %s -o jsonpath='{.metadata.labels}').", e.pod.Namespace, e.pod.Namespace, e.pod.Name, e.pod.Namespace, e.pod.Name)
+}
+
+// FixIt implements common.Runnable
+func (e EndpointsCheck) FixIt() error {
+	panic("implement me")
+}

--- a/pkg/kubernetes/podhelper/endpoints_test.go
+++ b/pkg/kubernetes/podhelper/endpoints_test.go
@@ -1,0 +1,223 @@
+package podhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm-health/pkg/common/outcomes"
+)
+
+func TestEndpointsCheck(t *testing.T) {
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		endpoints []*corev1.Endpoints
+		pass      bool
+	}{
+		{
+			name: "ok",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+				},
+			},
+			endpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "b",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									TargetRef: &corev1.ObjectReference{
+										Namespace: "b",
+										Name:      "a",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pass: true,
+		},
+		{
+			name: "no endpoints",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+				},
+			},
+			endpoints: nil,
+			pass:      false,
+		},
+		{
+			name: "endpoints in wrong namespace",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+				},
+			},
+			endpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "not-b",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									TargetRef: &corev1.ObjectReference{
+										Namespace: "not-b",
+										Name:      "a",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pass: false,
+		},
+		{
+			name: "ok when multiple Endpoints match",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+				},
+			},
+			endpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "a-unique-name",
+						Namespace: "b",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									TargetRef: &corev1.ObjectReference{
+										Namespace: "b",
+										Name:      "a",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "another-unique-name",
+						Namespace: "b",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									TargetRef: &corev1.ObjectReference{
+										Namespace: "b",
+										Name:      "a",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pass: true,
+		},
+		{
+			name: "ok when one of several Endpoints match",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+				},
+			},
+			endpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "a-unique-name",
+						Namespace: "b",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									TargetRef: &corev1.ObjectReference{
+										Namespace: "b",
+										Name:      "not-a",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "also-a-unique-name",
+						Namespace: "b",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									TargetRef: &corev1.ObjectReference{
+										Namespace: "b",
+										Name:      "a",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "another-unique-name",
+						Namespace: "b",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									TargetRef: &corev1.ObjectReference{
+										Namespace: "b",
+										Name:      "also-not-a",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pass: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			objs := make([]runtime.Object, len(test.endpoints))
+			for i := range test.endpoints {
+				objs[i] = test.endpoints[i]
+			}
+			client := fake.NewSimpleClientset(objs...)
+			check := NewEndpointsCheck(client, test.pod)
+			out := check.Run()
+			if test.pass {
+				assert.Equal(t, outcomes.SuccessfulOutcomeWithoutDiagnostics{}, out)
+			} else {
+				assert.Equal(t, ErrPodNotInEndpoints, out.GetError())
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/podhelper/errors.go
+++ b/pkg/kubernetes/podhelper/errors.go
@@ -16,4 +16,7 @@ var (
 
 	// ErrProxyUUIDLabelMissing is used when a pod is expected to have a valid proxy UUID label but does not
 	ErrProxyUUIDLabelMissing = errors.New("pod does not have expected valid proxy UUID label")
+
+	// ErrPodNotInEndpoints is used when a pod is expected to be referenced by any Kubernetes Endpoints resources but is not
+	ErrPodNotInEndpoints = errors.New("pod not referenced by any Kubernetes Endpoints resources")
 )


### PR DESCRIPTION
This change adds a new pod-to-pod connectivity check to verify the
destination pod is referenced in a Kubernetes Endpoints resource.