### PR TITLE
feat(osm): dynamically get osm version and mesh name

### DIFF
--- a/pkg/osm/utils.go
+++ b/pkg/osm/utils.go
@@ -1,0 +1,73 @@
+package osm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm-health/pkg/common"
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+// VersionDelimiter is a delimiter used in release versions
+const VersionDelimiter string = "."
+
+// MeshInfo is the type used to represent service mesh information
+type MeshInfo struct {
+	Name       common.MeshName
+	Namespace  common.MeshNamespace
+	OSMVersion ControllerVersion
+}
+
+// GetMeshInfo return the MeshInfo for a service mesh with its control plane in the given namespace
+func GetMeshInfo(client kubernetes.Interface, osmControlPlaneNamespace string) (*MeshInfo, error) {
+	osmControllerDeployment, err := GetOSMControllerDeployment(client, osmControlPlaneNamespace)
+	if err != nil {
+		return nil, err
+	}
+	osmVersion, err := FormatReleaseVersion(osmControllerDeployment.Labels[constants.OSMAppVersionLabelKey])
+	if err != nil {
+		return nil, err
+	}
+
+	mesh := &MeshInfo{
+		Name:       common.MeshName(osmControllerDeployment.Labels[constants.OSMAppNameLabelKey]),
+		Namespace:  common.MeshNamespace(osmControlPlaneNamespace),
+		OSMVersion: ControllerVersion(osmVersion),
+	}
+	return mesh, nil
+}
+
+// GetOSMControllerDeployment returns the OSM controller deployment in a given namespace
+func GetOSMControllerDeployment(client kubernetes.Interface, osmControlPlaneNamespace string) (*v1.Deployment, error) {
+	deploymentsClient := client.AppsV1().Deployments(osmControlPlaneNamespace)
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": constants.OSMControllerName}}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	}
+	deployments, err := deploymentsClient.List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+	if len(deployments.Items) == 0 {
+		return nil, fmt.Errorf("%s deployment not found in %s namespace", constants.OSMControllerName, osmControlPlaneNamespace)
+	} else if len(deployments.Items) > 1 {
+		return nil, fmt.Errorf("found more than one %s deployments in %s namespace", constants.OSMControllerName, osmControlPlaneNamespace)
+	}
+	return &deployments.Items[0], nil
+}
+
+// FormatReleaseVersion returns the major and minor version of the release
+func FormatReleaseVersion(version string) (string, error) {
+	splitVersion := strings.Split(version, VersionDelimiter)
+	if len(splitVersion) < 2 {
+		return "", fmt.Errorf(" is not in the expected format. The expected format is vXX.XX.XX or vXX.XX")
+	}
+	majorMinorVersion := splitVersion[0] + VersionDelimiter + splitVersion[1]
+	return majorMinorVersion, nil
+}

--- a/pkg/osm/utils_test.go
+++ b/pkg/osm/utils_test.go
@@ -1,0 +1,156 @@
+package osm
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func TestGetOSMControllerDeployment(t *testing.T) {
+	tests := []struct {
+		name        string
+		deployments []*v1.Deployment
+		namespace   string
+		expErr      bool
+	}{
+		{
+			name: "there are no deployments in the controller namespace",
+			deployments: []*v1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "notosmcontrollerdeployment",
+						Namespace: "notosmnamespace",
+						Labels: map[string]string{
+							constants.OSMAppInstanceLabelKey: "osm",
+							constants.OSMAppVersionLabelKey:  "v0.9.1",
+							"app":                            constants.OSMControllerName,
+						},
+					},
+				},
+			},
+			namespace: "osmnamespace",
+			expErr:    true,
+		},
+		{
+			name: "multiple deployments in the controller namespace",
+			deployments: []*v1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osmcontrollerdeployment",
+						Namespace: "osmnamespace",
+						Labels: map[string]string{
+							constants.OSMAppInstanceLabelKey: "osm",
+							constants.OSMAppVersionLabelKey:  "v0.9.1",
+							"app":                            constants.OSMControllerName,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osmcontrollerdeployment2",
+						Namespace: "osmnamespace",
+						Labels: map[string]string{
+							constants.OSMAppInstanceLabelKey: "osm",
+							constants.OSMAppVersionLabelKey:  "v0.9.1",
+							"app":                            constants.OSMControllerName,
+						},
+					},
+				},
+			},
+			namespace: "osmnamespace",
+			expErr:    true,
+		},
+		{
+			name: "there is one deployment in the controller namespace",
+			deployments: []*v1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osmcontrollerdeployment",
+						Namespace: "osmnamespace",
+						Labels: map[string]string{
+							constants.OSMAppInstanceLabelKey: "osm",
+							constants.OSMAppVersionLabelKey:  "v0.9.1",
+							"app":                            constants.OSMControllerName,
+						},
+					},
+				},
+			},
+			namespace: "osmnamespace",
+			expErr:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			objs := make([]runtime.Object, len(test.deployments))
+			for i := range test.deployments {
+				objs[i] = test.deployments[i]
+			}
+			k8s := fake.NewSimpleClientset(objs...)
+			deployment, err := GetOSMControllerDeployment(k8s, test.namespace)
+
+			assert.Equal(test.expErr, err != nil)
+			if !test.expErr {
+				assert.NotNil(deployment)
+				assert.Equal(test.deployments[0].Name, deployment.Name)
+			}
+		})
+	}
+}
+
+func TestFormatReleaseVersion(t *testing.T) {
+	tests := []struct {
+		name                      string
+		version                   string
+		expectedMajorMinorVersion string
+		expErr                    bool
+	}{
+		{
+			name:                      "major, minor and patch version",
+			version:                   "v0.9.0",
+			expectedMajorMinorVersion: "v0.9",
+			expErr:                    false,
+		},
+		{
+			name:                      "major and minor version",
+			version:                   "v0.8",
+			expectedMajorMinorVersion: "v0.8",
+			expErr:                    false,
+		},
+		{
+			name:                      "release cut version",
+			version:                   "v0.8.1-rc.1",
+			expectedMajorMinorVersion: "v0.8",
+			expErr:                    false,
+		},
+		{
+			name:                      "major version",
+			version:                   "v1",
+			expectedMajorMinorVersion: "",
+			expErr:                    true,
+		},
+		{
+			name:                      "empty version",
+			version:                   "",
+			expectedMajorMinorVersion: "",
+			expErr:                    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			majorMinorVersion, err := FormatReleaseVersion(test.version)
+
+			assert.Equal(test.expErr, err != nil)
+			assert.Equal(test.expectedMajorMinorVersion, majorMinorVersion)
+		})
+	}
+}


### PR DESCRIPTION
Removes the hard-coded OSM version and mesh name in the pod-to-pod connectivity check. The OSM version and mesh name are obtained from the label values in the OSM controller deployment using the given controller namespace.

As an alternative to this solution the `/version` endpoint on the `osm-controller` pod could be queried to obtain the OSM version and mesh name.