### PR TITLE
chore(smi): Refactor route kind support check

### DIFF
--- a/pkg/osm/smi.go
+++ b/pkg/osm/smi.go
@@ -1,5 +1,7 @@
 package osm
 
+import "github.com/openservicemesh/osm-health/pkg/smi"
+
 // SupportedTrafficTarget is a map of OSM Controller Version to supported
 var SupportedTrafficTarget = map[ControllerVersion]TrafficTargetVersion{
 	// Source: https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L8
@@ -16,6 +18,49 @@ var SupportedTrafficTarget = map[ControllerVersion]TrafficTargetVersion{
 
 	// Source: https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/smi/client.go#L10
 	"v0.9": "v1alpha3",
+}
+
+// SupportedTrafficTargetRouteKinds is a map of OSM Controller Version to supported SMI TrafficTarget Route Kinds.
+var SupportedTrafficTargetRouteKinds = map[ControllerVersion][]TrafficTargetRouteKind{
+	// Source:
+	// https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L67
+	// https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L68
+	"v0.5": {
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind,
+	},
+
+	// Sources:
+	// https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L68
+	// https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L69
+	"v0.6": {
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind,
+	},
+
+	// Sources:
+	// https://github.com/openservicemesh/osm/blob/release-v0.7/pkg/smi/client.go#L68
+	// https://github.com/openservicemesh/osm/blob/release-v0.7/pkg/smi/client.go#L69
+	"v0.7": {
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind,
+	},
+
+	// Sources:
+	// https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/smi/client.go#L58
+	// https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/smi/client.go#L59
+	"v0.8": {
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind,
+	},
+
+	// Sources:
+	// https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/smi/client.go#L60
+	// https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/smi/client.go#L61
+	"v0.9": {
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind,
+	},
 }
 
 // SupportedTrafficSplit is the mapping of OSM Controller version to supported SMI TrafficSplit version.
@@ -36,7 +81,6 @@ var SupportedHTTPRouteVersion = map[ControllerVersion][]HTTPRouteVersion{
 		"v1alpha3",
 	},
 	"v0.7": {
-
 		"v1alpha4",
 	},
 	"v0.8": {

--- a/pkg/osm/types.go
+++ b/pkg/osm/types.go
@@ -13,6 +13,9 @@ type IngressVersion string
 // TrafficTargetVersion is a string type alias for the SMI TrafficTarget version supported.
 type TrafficTargetVersion string
 
+// TrafficTargetRouteKind is a string type alias for the SMI TrafficTarget route kind supported.
+type TrafficTargetRouteKind string
+
 // TrafficSplitVersion is a string type alias for the SMI TrafficSplit version supported.
 type TrafficSplitVersion string
 

--- a/pkg/osm/types_test.go
+++ b/pkg/osm/types_test.go
@@ -30,6 +30,11 @@ func TestEnvoyConfigParser(t *testing.T) {
 		}
 
 		{
+			_, exists := SupportedTrafficTargetRouteKinds[controllerVersion]
+			assert.Truef(exists, "SupportedTrafficTargetRouteKinds does not contain info on OSM release %s", release)
+		}
+
+		{
 			_, exists := SupportedTrafficSplit[controllerVersion]
 			assert.Truef(exists, "SupportedTrafficSplit does not contain info on OSM release %s", release)
 		}

--- a/pkg/smi/access/errors.go
+++ b/pkg/smi/access/errors.go
@@ -1,0 +1,11 @@
+package access
+
+import "errors"
+
+var (
+	// ErrorUnknownSupportForRouteKindUnknownOsmVersion is the error for unknown osm versions when checking for supported traffic target route kinds.
+	ErrorUnknownSupportForRouteKindUnknownOsmVersion = errors.New("unknown osm version: no info on supported traffic target route kinds for specified osm version")
+
+	// ErrorUnsupportedRouteKind is the error if the osm version does not support the TrafficTarget route kind.
+	ErrorUnsupportedRouteKind = errors.New("unsupported traffic target route kind")
+)

--- a/pkg/smi/access/routes.go
+++ b/pkg/smi/access/routes.go
@@ -1,0 +1,19 @@
+package access
+
+import (
+	"github.com/openservicemesh/osm-health/pkg/osm"
+)
+
+// isTrafficTargetRouteKindSupported checks whether an SMI TrafficTarget Route Kind is supported.
+func isTrafficTargetRouteKindSupported(routeKind string, osmVersion osm.ControllerVersion) error {
+	supportedRouteKinds, ok := osm.SupportedTrafficTargetRouteKinds[osmVersion]
+	if !ok {
+		return ErrorUnknownSupportForRouteKindUnknownOsmVersion
+	}
+	for _, supportedRouteKind := range supportedRouteKinds {
+		if routeKind == string(supportedRouteKind) {
+			return nil
+		}
+	}
+	return ErrorUnsupportedRouteKind
+}

--- a/pkg/smi/access/routes_existence.go
+++ b/pkg/smi/access/routes_existence.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/openservicemesh/osm-health/pkg/common/outcomes"
 	"github.com/openservicemesh/osm-health/pkg/osm"
-	"github.com/openservicemesh/osm-health/pkg/smi"
 	"github.com/openservicemesh/osm-health/pkg/smi/access/v1alpha2"
 	"github.com/openservicemesh/osm-health/pkg/smi/access/v1alpha3"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -90,7 +89,8 @@ func (check RoutesExistenceCheck) runForTrafficTargetV1alpha2() outcomes.Outcome
 		}
 		foundMatchingTarget = true
 		for _, rule := range spec.Rules {
-			if isValidRoute(rule.Kind) && !(existingRoutes.Contains(rule.Name)) {
+			err = isTrafficTargetRouteKindSupported(rule.Kind, check.osmVersion)
+			if err == nil && !(existingRoutes.Contains(rule.Name)) {
 				missingRoutes = append(missingRoutes, rule.Name)
 			}
 		}
@@ -127,7 +127,8 @@ func (check RoutesExistenceCheck) runForTrafficTargetV1alpha3() outcomes.Outcome
 		}
 		foundMatchingTarget = true
 		for _, rule := range spec.Rules {
-			if isValidRoute(rule.Kind) && !(existingRoutes.Contains(rule.Name)) {
+			err = isTrafficTargetRouteKindSupported(rule.Kind, check.osmVersion)
+			if err == nil && !(existingRoutes.Contains(rule.Name)) {
 				missingRoutes = append(missingRoutes, rule.Name)
 			}
 		}
@@ -139,11 +140,6 @@ func (check RoutesExistenceCheck) runForTrafficTargetV1alpha3() outcomes.Outcome
 		return outcomes.Fail{Error: fmt.Errorf("The following routes could not be found in the cluster: %s", strings.Join(missingRoutes, ", "))}
 	}
 	return outcomes.Pass{}
-}
-
-// TODO: update if supported routes change for the OSM controller
-func isValidRoute(routeKind string) bool {
-	return (routeKind == smi.HTTPRouteGroupKind || routeKind == smi.TCPRouteKind)
 }
 
 // Suggestion implements common.Runnable

--- a/pkg/smi/access/routes_test.go
+++ b/pkg/smi/access/routes_test.go
@@ -1,0 +1,52 @@
+package access
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm-health/pkg/osm"
+	"github.com/openservicemesh/osm-health/pkg/smi"
+)
+
+func TestIsTrafficTargetRouteKindSupported(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		routeKind string
+		expErr    error
+	}{
+		{
+			name:      "known osm version and supported route kind - HTTPRouteGroupKind",
+			version:   "v0.9",
+			routeKind: smi.HTTPRouteGroupKind,
+			expErr:    nil,
+		},
+		{
+			name:      "known osm version and supported route kind - TCPRouteKind",
+			version:   "v0.9",
+			routeKind: smi.TCPRouteKind,
+			expErr:    nil,
+		},
+		{
+			name:      "known osm version and unsupported route kind",
+			version:   "v0.9",
+			routeKind: "some-other-route-kind",
+			expErr:    ErrorUnsupportedRouteKind,
+		},
+		{
+			name:      "unknown osm version",
+			version:   "v-abc-def-xxx",
+			routeKind: "some-other-route-kind",
+			expErr:    ErrorUnknownSupportForRouteKindUnknownOsmVersion,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			err := isTrafficTargetRouteKindSupported(test.routeKind, osm.ControllerVersion(test.version))
+			assert.Equal(test.expErr, err)
+		})
+	}
+}

--- a/pkg/smi/access/routes_validity.go
+++ b/pkg/smi/access/routes_validity.go
@@ -85,8 +85,8 @@ func (check RoutesValidityCheck) runForTrafficTargetV1alpha2() outcomes.Outcome 
 		foundMatchingTarget = true
 		for _, rule := range spec.Rules {
 			kind := rule.Kind
-			// TODO: update if supported routes change for the OSM controller
-			if !(kind == smi.HTTPRouteGroupKind || kind == smi.TCPRouteKind) {
+			err = isTrafficTargetRouteKindSupported(kind, check.osmVersion)
+			if err != nil {
 				unsupportedRouteTargets[trafficTarget.Name] = kind
 			}
 		}
@@ -119,8 +119,8 @@ func (check RoutesValidityCheck) runForTrafficTargetV1alpha3() outcomes.Outcome 
 		foundMatchingTarget = true
 		for _, rule := range spec.Rules {
 			kind := rule.Kind
-			// TODO: update if supported routes change for the OSM controller
-			if !(kind == smi.HTTPRouteGroupKind || kind == smi.TCPRouteKind) {
+			err = isTrafficTargetRouteKindSupported(kind, check.osmVersion)
+			if err != nil {
 				unsupportedRouteTargets[trafficTarget.Name] = kind
 			}
 		}


### PR DESCRIPTION
chore(smi): Refactor route kind support check

Refactors TrafficTarget route kind support check
to check for the supported route kinds per osm version.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>