### PR TITLE
Check for envoy dynamic warming issues

### DIFF
--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -128,6 +128,10 @@ func PodToPod(srcPod *corev1.Pod, dstPod *corev1.Pod, osmControlPlaneNamespace c
 		envoy.HasServiceCertificate(client, srcConfigGetter, srcPod),
 		envoy.HasServiceCertificate(client, dstConfigGetter, dstPod),
 
+		// Check Envoy for dynamic warming issues
+		envoy.NewDynamicWarmingCheck(srcConfigGetter),
+		envoy.NewDynamicWarmingCheck(dstConfigGetter),
+
 		// Run SMI checks
 		split.NewTrafficSplitCheck(meshInfo.OSMVersion, client, dstPod, splitClient),
 		access.NewTrafficTargetCheck(meshInfo.OSMVersion, configurator, srcPod, dstPod, accessClient),

--- a/pkg/envoy/dynamic_warming.go
+++ b/pkg/envoy/dynamic_warming.go
@@ -1,0 +1,60 @@
+package envoy
+
+import (
+	"fmt"
+
+	"github.com/openservicemesh/osm-health/pkg/common/outcomes"
+	"github.com/openservicemesh/osm-health/pkg/runner"
+)
+
+// Verify interface compliance
+var _ runner.Runnable = (*DynamicWarmingCheck)(nil)
+
+// DynamicWarmingCheck implements common.Runnable
+type DynamicWarmingCheck struct {
+	ConfigGetter
+}
+
+// Run implements common.Runnable
+func (l DynamicWarmingCheck) Run() outcomes.Outcome {
+	if l.ConfigGetter == nil {
+		log.Error().Msg("Incorrectly initialized ConfigGetter")
+		return outcomes.Fail{Error: ErrIncorrectlyInitializedConfigGetter}
+	}
+	envoyConfig, err := l.ConfigGetter.GetConfig()
+	if err != nil {
+		return outcomes.Fail{Error: err}
+	}
+
+	if envoyConfig == nil {
+		return outcomes.Fail{Error: ErrEnvoyConfigEmpty}
+	}
+
+	if len(envoyConfig.SecretsConfigDump.DynamicWarmingSecrets) > 0 {
+		return outcomes.Fail{Error: ErrDynamicWarmingSecretsConfigDumpNotEmpty}
+	}
+
+	return outcomes.Pass{}
+}
+
+// Suggestion implements common.Runnable
+func (l DynamicWarmingCheck) Suggestion() string {
+	panic("implement me")
+}
+
+// FixIt implements common.Runnable
+func (l DynamicWarmingCheck) FixIt() error {
+	panic("implement me")
+}
+
+// Description implements common.Runnable
+func (l DynamicWarmingCheck) Description() string {
+	return fmt.Sprintf("Checking whether %s has dynamic warming issues", l.ConfigGetter.GetObjectName())
+}
+
+// NewDynamicWarmingCheck creates a DynamicWarmingCheck which checks whether the given Pod's envoy has dynamic warming issues.
+func NewDynamicWarmingCheck(configGetter ConfigGetter) DynamicWarmingCheck {
+	return DynamicWarmingCheck{
+		ConfigGetter: configGetter,
+	}
+}

--- a/pkg/envoy/dynamic_warming_test.go
+++ b/pkg/envoy/dynamic_warming_test.go
@@ -1,0 +1,78 @@
+package envoy
+
+import (
+	"testing"
+
+	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestDynamicWarmingCheck(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		expectedErr error
+	}{
+		{
+			name:        "no config",
+			config:      nil,
+			expectedErr: ErrEnvoyConfigEmpty,
+		},
+		{
+			name: "no dynamic warming secrets in secrets config dump",
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "nil dynamic warming secrets in secrets config dump",
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicWarmingSecrets: nil,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty length dynamic warming secrets in secrets config dump",
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicWarmingSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "dynamic warming secrets present in secrets config dump",
+			config: &Config{
+				SecretsConfigDump: adminv3.SecretsConfigDump{
+					DynamicWarmingSecrets: []*adminv3.SecretsConfigDump_DynamicSecret{
+						{
+							Name: "dynamic-warming-secret",
+						},
+					},
+				},
+			},
+			expectedErr: ErrDynamicWarmingSecretsConfigDumpNotEmpty,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			configGetter := mockConfigGetter{
+				getter: func() (*Config, error) {
+					return test.config, nil
+				},
+			}
+			dynamicWarmingChecker := NewDynamicWarmingCheck(configGetter)
+			outcome := dynamicWarmingChecker.Run()
+			if test.expectedErr == nil {
+				assert.Nil(outcome.GetError())
+			} else {
+				assert.Equal(test.expectedErr.Error(), outcome.GetError().Error())
+			}
+		})
+	}
+}

--- a/pkg/envoy/errors.go
+++ b/pkg/envoy/errors.go
@@ -41,4 +41,7 @@ var (
 
 	// ErrDynamicRouteConfigDomainNotFound is an error returned when a specific dynamic route config domain is not found.
 	ErrDynamicRouteConfigDomainNotFound = errors.New("dynamic route config domain not found")
+
+	// ErrDynamicWarmingSecretsConfigDumpNotEmpty is an error returned when the pod's envoy is possibly experiencing dynamic warming issues.
+	ErrDynamicWarmingSecretsConfigDumpNotEmpty = errors.New("possible dynamic warming issue due to non-empty dynamic warming secrets in envoy's secrets config dump")
 )


### PR DESCRIPTION
For pod-to-pod connectivity checks, check a pod's envoy
for possible dynamic warming issues.
Dynamic warming issues may be present if the pod envoy's
dynamic warming secrets in secrets config dump is not empty.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>