### PR TITLE
feat(*): support osm-health for osm v0.10 & v0.11

### DIFF
--- a/pkg/envoy/config.go
+++ b/pkg/envoy/config.go
@@ -3,6 +3,7 @@ package envoy
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm-health/pkg/kubernetes/pod"
@@ -30,9 +31,11 @@ func (mcg ConfigGetterStruct) GetConfig() (*Config, error) {
 
 	namespace := mcg.Pod.Namespace
 	podName := mcg.Pod.Name
-	localPort := version.EnvoyAdminPort[mcg.ControllerVersion]
+	localPort, ok := version.EnvoyAdminPort[mcg.ControllerVersion]
+	if !ok {
+		return nil, errors.Errorf("unable to determine envoy admin port due to unrecognized osm-controller version: %s", mcg.ControllerVersion)
+	}
 	query := "config_dump?include_eds"
-	// This function becomes available in github.com/openservicemesh/osm at 9be251135819c360ce2b9cf77087c88ab1e3f54a
 	configBytes, err := osmCLI.GetEnvoyProxyConfig(client, config, namespace, podName, localPort, query)
 	if err != nil {
 		return nil, err

--- a/pkg/envoy/lds.go
+++ b/pkg/envoy/lds.go
@@ -165,7 +165,7 @@ func (l ListenerFilterCheck) Run() outcomes.Outcome {
 		ruleTypes, err = getRuleTypesFromMatchingTrafficTargetsV1alpha3(l.srcPod, l.dstPod, l.accessClient)
 	default:
 		return outcomes.Fail{Error: fmt.Errorf(
-			"OSM Controller version could not be mapped to a TrafficTarget version. Supported versions are v0.5 through v0.9")}
+			"OSM Controller version could not be mapped to a TrafficTarget version. Supported versions are v0.6 through v0.11")}
 	}
 	if err != nil {
 		return outcomes.Info{Diagnostics: fmt.Sprintf(

--- a/pkg/envoy/lds.go
+++ b/pkg/envoy/lds.go
@@ -352,7 +352,6 @@ func findMatchingFilterChainNames(envoyConfig *Config, expectedListenerName stri
 				return ErrUnmarshalingListener
 			}
 			for _, listenerFilter := range listener.FilterChains {
-				log.Error().Msg(listenerFilter.Name)
 				// Check filter chain name
 				actualFilterChainNames = append(actualFilterChainNames, listenerFilter.Name)
 				for expectedFilterChainName := range possibleFilterChainNames {

--- a/pkg/envoy/rds.go
+++ b/pkg/envoy/rds.go
@@ -2,6 +2,7 @@ package envoy
 
 import (
 	"fmt"
+	"strings"
 
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +48,7 @@ func (check RouteDomainCheck) Run() outcomes.Outcome {
 			return outcomes.Fail{Error: ErrUnmarshalingDynamicRouteConfig}
 		}
 
-		if dynRouteCfg.Name != check.RouteName {
+		if !strings.HasPrefix(dynRouteCfg.Name, check.RouteName) {
 			continue
 		}
 

--- a/pkg/osm/utils/utils.go
+++ b/pkg/osm/utils/utils.go
@@ -67,10 +67,13 @@ func GetOSMControllerDeployment(client kubernetes.Interface, osmControlPlaneName
 // FormatReleaseVersion returns the major and minor version of the release
 func FormatReleaseVersion(version string) (string, error) {
 	splitVersion := strings.Split(version, versionDelimiter)
-	if len(splitVersion) < 2 {
+	if len(splitVersion) < 2 || len(splitVersion[0]) == 0 {
 		return "", fmt.Errorf("%s is not in the expected format", version)
 	}
 	majorMinorVersion := splitVersion[0] + versionDelimiter + splitVersion[1]
+	if majorMinorVersion[0] != 'v' {
+		majorMinorVersion = "v" + majorMinorVersion
+	}
 	return majorMinorVersion, nil
 }
 

--- a/pkg/osm/utils/utils_test.go
+++ b/pkg/osm/utils/utils_test.go
@@ -235,8 +235,20 @@ func TestFormatReleaseVersion(t *testing.T) {
 			expErr:                    false,
 		},
 		{
+			name:                      "major, minor and patch version without v prefix",
+			version:                   "0.9.0",
+			expectedMajorMinorVersion: "v0.9",
+			expErr:                    false,
+		},
+		{
 			name:                      "major and minor version",
 			version:                   "v0.8",
+			expectedMajorMinorVersion: "v0.8",
+			expErr:                    false,
+		},
+		{
+			name:                      "major and minor version without v prefix",
+			version:                   "0.8",
 			expectedMajorMinorVersion: "v0.8",
 			expErr:                    false,
 		},
@@ -245,6 +257,12 @@ func TestFormatReleaseVersion(t *testing.T) {
 			version:                   "v0.8.1-rc.1",
 			expectedMajorMinorVersion: "v0.8",
 			expErr:                    false,
+		},
+		{
+			name:                      "incorrectly-formatted version",
+			version:                   ".1.2",
+			expectedMajorMinorVersion: "",
+			expErr:                    true,
 		},
 		{
 			name:                      "major version",

--- a/pkg/osm/version/annotations.go
+++ b/pkg/osm/version/annotations.go
@@ -29,4 +29,18 @@ var SupportedAnnotations = map[ControllerVersion][]Annotation{
 		"openservicemesh.io/outbound-port-exclusion-list",
 		"openservicemesh.io/inbound-port-exclusion-list",
 	},
+	"v0.10": {
+		"openservicemesh.io/monitored-by",
+		"openservicemesh.io/sidecar-injection",
+		"openservicemesh.io/metrics",
+		"openservicemesh.io/outbound-port-exclusion-list",
+		"openservicemesh.io/inbound-port-exclusion-list",
+	},
+	"v0.11": {
+		"openservicemesh.io/monitored-by",
+		"openservicemesh.io/sidecar-injection",
+		"openservicemesh.io/metrics",
+		"openservicemesh.io/outbound-port-exclusion-list",
+		"openservicemesh.io/inbound-port-exclusion-list",
+	},
 }

--- a/pkg/osm/version/annotations.go
+++ b/pkg/osm/version/annotations.go
@@ -2,11 +2,6 @@ package version
 
 // SupportedAnnotations maintains a mapping of OSM version to supported annotations.
 var SupportedAnnotations = map[ControllerVersion][]Annotation{
-	"v0.5": {
-		"openservicemesh.io/monitored-by",
-		"openservicemesh.io/sidecar-injection",
-		"openservicemesh.io/metrics",
-	},
 	"v0.6": {
 		"openservicemesh.io/monitored-by",
 		"openservicemesh.io/sidecar-injection",

--- a/pkg/osm/version/envoy.go
+++ b/pkg/osm/version/envoy.go
@@ -2,9 +2,11 @@ package version
 
 // EnvoyAdminPort is the admin port number of Envoys configured by the given version of the OSM Controller.
 var EnvoyAdminPort = map[ControllerVersion]uint16{
-	"v0.5": 15000,
-	"v0.6": 15000,
-	"v0.7": 15000,
-	"v0.8": 15000,
-	"v0.9": 15000,
+	"v0.5":  15000,
+	"v0.6":  15000,
+	"v0.7":  15000,
+	"v0.8":  15000,
+	"v0.9":  15000,
+	"v0.10": 15000,
+	"v0.11": 15000,
 }

--- a/pkg/osm/version/envoy.go
+++ b/pkg/osm/version/envoy.go
@@ -2,7 +2,6 @@ package version
 
 // EnvoyAdminPort is the admin port number of Envoys configured by the given version of the OSM Controller.
 var EnvoyAdminPort = map[ControllerVersion]uint16{
-	"v0.5":  15000,
 	"v0.6":  15000,
 	"v0.7":  15000,
 	"v0.8":  15000,

--- a/pkg/osm/version/ingress.go
+++ b/pkg/osm/version/ingress.go
@@ -23,4 +23,14 @@ var SupportedIngress = map[ControllerVersion][]IngressVersion{
 		"networking/v1",
 		"networking/v1beta1",
 	},
+	"v0.10": {
+		// Source: https://github.com/openservicemesh/osm/blob/release-v0.10/pkg/ingress/client.go#L5-L6
+		"networking/v1",
+		"networking/v1beta1",
+	},
+	"v0.11": {
+		// Source: https://github.com/openservicemesh/osm/blob/release-v0.11/pkg/ingress/client.go#L5-L6
+		"networking/v1",
+		"networking/v1beta1",
+	},
 }

--- a/pkg/osm/version/ingress.go
+++ b/pkg/osm/version/ingress.go
@@ -2,10 +2,6 @@ package version
 
 // SupportedIngress maintains a mapping of OSM version to supported Ingress resource versions.
 var SupportedIngress = map[ControllerVersion][]IngressVersion{
-	"v0.5": {
-		// Source: https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/ingress/client.go#L6
-		"extensions/v1beta1",
-	},
 	"v0.6": {
 		// Source: https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/ingress/client.go#L6
 		"extensions/v1beta1",

--- a/pkg/osm/version/listener_names_per_osm_version.go
+++ b/pkg/osm/version/listener_names_per_osm_version.go
@@ -2,18 +2,22 @@ package version
 
 // OutboundListenerNames is the name of the Envoy listener expected to be created by a certain version of the OSM Controller.
 var OutboundListenerNames = map[ControllerVersion]string{
-	"v0.5": "outbound-listener",
-	"v0.6": "outbound-listener",
-	"v0.7": "outbound-listener",
-	"v0.8": "outbound-listener",
-	"v0.9": "outbound-listener",
+	"v0.5":  "outbound-listener",
+	"v0.6":  "outbound-listener",
+	"v0.7":  "outbound-listener",
+	"v0.8":  "outbound-listener",
+	"v0.9":  "outbound-listener",
+	"v0.10": "outbound-listener",
+	"v0.11": "outbound-listener",
 }
 
 // InboundListenerNames is the name of the Envoy listener expected to be created by a certain version of the OSM Controller.
 var InboundListenerNames = map[ControllerVersion]string{
-	"v0.5": "inbound-listener",
-	"v0.6": "inbound-listener",
-	"v0.7": "inbound-listener",
-	"v0.8": "inbound-listener",
-	"v0.9": "inbound-listener",
+	"v0.5":  "inbound-listener",
+	"v0.6":  "inbound-listener",
+	"v0.7":  "inbound-listener",
+	"v0.8":  "inbound-listener",
+	"v0.9":  "inbound-listener",
+	"v0.10": "inbound-listener",
+	"v0.11": "inbound-listener",
 }

--- a/pkg/osm/version/listener_names_per_osm_version.go
+++ b/pkg/osm/version/listener_names_per_osm_version.go
@@ -2,7 +2,6 @@ package version
 
 // OutboundListenerNames is the name of the Envoy listener expected to be created by a certain version of the OSM Controller.
 var OutboundListenerNames = map[ControllerVersion]string{
-	"v0.5":  "outbound-listener",
 	"v0.6":  "outbound-listener",
 	"v0.7":  "outbound-listener",
 	"v0.8":  "outbound-listener",
@@ -13,7 +12,6 @@ var OutboundListenerNames = map[ControllerVersion]string{
 
 // InboundListenerNames is the name of the Envoy listener expected to be created by a certain version of the OSM Controller.
 var InboundListenerNames = map[ControllerVersion]string{
-	"v0.5":  "inbound-listener",
 	"v0.6":  "inbound-listener",
 	"v0.7":  "inbound-listener",
 	"v0.8":  "inbound-listener",

--- a/pkg/osm/version/smi.go
+++ b/pkg/osm/version/smi.go
@@ -20,6 +20,12 @@ var SupportedTrafficTarget = map[ControllerVersion]TrafficTargetVersion{
 
 	// Source: https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/smi/client.go#L10
 	"v0.9": "v1alpha3",
+
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.10/pkg/smi/client.go#L9
+	"v0.10": "v1alpha3",
+
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.11/pkg/smi/client.go#L9
+	"v0.11": "v1alpha3",
 }
 
 // SupportedTrafficTargetRouteKinds is a map of OSM Controller Version to supported SMI TrafficTarget Route Kinds.
@@ -63,32 +69,76 @@ var SupportedTrafficTargetRouteKinds = map[ControllerVersion][]TrafficTargetRout
 		smi.HTTPRouteGroupKind,
 		smi.TCPRouteKind,
 	},
+
+	// Sources:
+	// https://github.com/openservicemesh/osm/blob/release-v0.10/pkg/smi/client.go#L61
+	// https://github.com/openservicemesh/osm/blob/release-v0.10/pkg/smi/client.go#L62
+	"v0.10": {
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind,
+	},
+
+	// Sources:
+	// https://github.com/openservicemesh/osm/blob/release-v0.11/pkg/smi/client.go#L61
+	// https://github.com/openservicemesh/osm/blob/release-v0.11/pkg/smi/client.go#L62
+	"v0.11": {
+		smi.HTTPRouteGroupKind,
+		smi.TCPRouteKind,
+	},
 }
 
 // SupportedTrafficSplit is the mapping of OSM Controller version to supported SMI TrafficSplit version.
 var SupportedTrafficSplit = map[ControllerVersion]TrafficSplitVersion{
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L10
 	"v0.5": "v1alpha2",
+
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L10
 	"v0.6": "v1alpha2",
+
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.7/pkg/smi/client.go#L10
 	"v0.7": "v1alpha2",
+
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/smi/client.go#L10
 	"v0.8": "v1alpha2",
+
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/smi/client.go#L12
 	"v0.9": "v1alpha2",
+
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.10/pkg/smi/client.go#L11
+	"v0.10": "v1alpha2",
+
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.11/pkg/smi/client.go#L11
+	"v0.11": "v1alpha2",
 }
 
 // SupportedHTTPRouteVersion is a mapping of OSM Controller version to supported HTTP Route Group version.
 var SupportedHTTPRouteVersion = map[ControllerVersion][]HTTPRouteVersion{
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L9
 	"v0.5": {
 		"v1alpha3",
 	},
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L9
 	"v0.6": {
 		"v1alpha3",
 	},
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.7/pkg/smi/client.go#L9
 	"v0.7": {
 		"v1alpha4",
 	},
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/smi/client.go#L9
 	"v0.8": {
 		"v1alpha4",
 	},
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.9/pkg/smi/client.go#L11
 	"v0.9": {
+		"v1alpha4",
+	},
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.10/pkg/smi/client.go#L10
+	"v0.10": {
+		"v1alpha4",
+	},
+	// Source: https://github.com/openservicemesh/osm/blob/release-v0.11/pkg/smi/client.go#L10
+	"v0.11": {
 		"v1alpha4",
 	},
 }

--- a/pkg/osm/version/smi.go
+++ b/pkg/osm/version/smi.go
@@ -6,8 +6,6 @@ import (
 
 // SupportedTrafficTarget is a map of OSM Controller Version to supported
 var SupportedTrafficTarget = map[ControllerVersion]TrafficTargetVersion{
-	// Source: https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L8
-	"v0.5": "v1alpha2",
 
 	// Source: https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L8
 	"v0.6": "v1alpha2",
@@ -30,14 +28,6 @@ var SupportedTrafficTarget = map[ControllerVersion]TrafficTargetVersion{
 
 // SupportedTrafficTargetRouteKinds is a map of OSM Controller Version to supported SMI TrafficTarget Route Kinds.
 var SupportedTrafficTargetRouteKinds = map[ControllerVersion][]TrafficTargetRouteKind{
-	// Source:
-	// https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L67
-	// https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L68
-	"v0.5": {
-		smi.HTTPRouteGroupKind,
-		smi.TCPRouteKind,
-	},
-
 	// Sources:
 	// https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L68
 	// https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L69
@@ -89,9 +79,6 @@ var SupportedTrafficTargetRouteKinds = map[ControllerVersion][]TrafficTargetRout
 
 // SupportedTrafficSplit is the mapping of OSM Controller version to supported SMI TrafficSplit version.
 var SupportedTrafficSplit = map[ControllerVersion]TrafficSplitVersion{
-	// Source: https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L10
-	"v0.5": "v1alpha2",
-
 	// Source: https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L10
 	"v0.6": "v1alpha2",
 
@@ -113,10 +100,6 @@ var SupportedTrafficSplit = map[ControllerVersion]TrafficSplitVersion{
 
 // SupportedHTTPRouteVersion is a mapping of OSM Controller version to supported HTTP Route Group version.
 var SupportedHTTPRouteVersion = map[ControllerVersion][]HTTPRouteVersion{
-	// Source: https://github.com/openservicemesh/osm/blob/release-v0.5/pkg/smi/client.go#L9
-	"v0.5": {
-		"v1alpha3",
-	},
 	// Source: https://github.com/openservicemesh/osm/blob/release-v0.6/pkg/smi/client.go#L9
 	"v0.6": {
 		"v1alpha3",

--- a/pkg/osm/version/types_test.go
+++ b/pkg/osm/version/types_test.go
@@ -15,7 +15,7 @@ func TestEnvoyConfigParser(t *testing.T) {
 	assert := tassert.New(t)
 	actual := getReleases()
 
-	assert.Equal(actual, []string{"v0.5", "v0.6", "v0.7", "v0.8", "v0.9"})
+	assert.Equal(actual, []string{"v0.10", "v0.11", "v0.5", "v0.6", "v0.7", "v0.8", "v0.9"})
 
 	for _, release := range actual {
 		controllerVersion := ControllerVersion(release)
@@ -48,6 +48,21 @@ func TestEnvoyConfigParser(t *testing.T) {
 			_, exists := SupportedAnnotations[controllerVersion]
 			assert.Truef(exists, "SupportedAnnotations does not contain info on OSM release %s", release)
 		}
+
+		{
+			_, exists := EnvoyAdminPort[controllerVersion]
+			assert.Truef(exists, "EnvoyAdminPort does not contain info on OSM release %s", release)
+		}
+
+		{
+			_, exists := OutboundListenerNames[controllerVersion]
+			assert.Truef(exists, "OutboundListenerNames does not contain info on OSM release %s", release)
+		}
+
+		{
+			_, exists := InboundListenerNames[controllerVersion]
+			assert.Truef(exists, "InboundListenerNames does not contain info on OSM release %s", release)
+		}
 	}
 }
 
@@ -76,11 +91,10 @@ func getReleases() []string {
 	}
 
 	ignore := map[string]interface{}{
-		"v0.1":  nil,
-		"v0.2":  nil,
-		"v0.3":  nil,
-		"v0.4":  nil,
-		"v0.10": nil,
+		"v0.1": nil,
+		"v0.2": nil,
+		"v0.3": nil,
+		"v0.4": nil,
 	}
 	releases := make(map[string]interface{})
 

--- a/pkg/osm/version/types_test.go
+++ b/pkg/osm/version/types_test.go
@@ -15,7 +15,7 @@ func TestEnvoyConfigParser(t *testing.T) {
 	assert := tassert.New(t)
 	actual := getReleases()
 
-	assert.Equal(actual, []string{"v0.10", "v0.11", "v0.5", "v0.6", "v0.7", "v0.8", "v0.9"})
+	assert.Equal([]string{"v0.10", "v0.11", "v0.6", "v0.7", "v0.8", "v0.9"}, actual)
 
 	for _, release := range actual {
 		controllerVersion := ControllerVersion(release)
@@ -90,12 +90,6 @@ func getReleases() []string {
 		log.Fatal().Err(err)
 	}
 
-	ignore := map[string]interface{}{
-		"v0.1": nil,
-		"v0.2": nil,
-		"v0.3": nil,
-		"v0.4": nil,
-	}
 	releases := make(map[string]interface{})
 
 	for _, releaseJSON := range res {
@@ -114,9 +108,6 @@ func getReleases() []string {
 			continue
 		}
 		release := fmt.Sprintf("%s.%s", majorMinorChunks[0], majorMinorChunks[1])
-		if _, shouldIgnore := ignore[release]; shouldIgnore {
-			continue
-		}
 		releases[release] = nil
 	}
 


### PR DESCRIPTION
* Check for Envoy cluster name prefix in pod-to-pod cds check.
For osm v0.10 onwards, the Envoy cluster name in the cds check
may have the port number appended to the cluster name.

* Add EnvoyAdminPort information for osm v0.10 & v0.11.

* Check for Envoy listener name prefix in pod-to-pod filter chains check.
For osm v0.10 onwards, the Envoy filter chains have the port number
and traffic type appended. When checking for possible filter chain
names, check for the prefix instead (without the port num & traffic type).

* Check for Envoy route domain service name prefix in pod-to-pod
rds check. For osm v0.10 onwards, rds dynamic_route_config names
have the port number appended.

* Add info for osm v0.10 and v0.11 in pkg/osm/version checks and utils.

* Ensure release version format util always returns 'v' prefix
when formatting major-minor version.

* Remove ignoring of osm v0.10 in release getter util.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>