### PR TITLE
fix(connectivity): return early on fatal errors

### DIFF
--- a/pkg/connectivity/pod-to-pod.go
+++ b/pkg/connectivity/pod-to-pod.go
@@ -25,16 +25,19 @@ func PodToPod(srcPod *corev1.Pod, dstPod *corev1.Pod, osmControlPlaneNamespace c
 	client, err := pod.GetKubeClient()
 	if err != nil {
 		log.Error().Err(err).Msg("Error creating Kubernetes client")
+		return
 	}
 
 	meshInfo, err := utils.GetMeshInfo(client, osmControlPlaneNamespace)
 	if err != nil {
-		log.Err(err).Msg("Error getting OSM info")
+		log.Err(err).Msg("Error getting OSM info. Try running again with the `--osm-namespace` option to specify the osm control plane namespace")
+		return
 	}
 
 	kubeConfig, err := pod.GetKubeConfig()
 	if err != nil {
 		log.Error().Err(err).Msg("Error getting Kubernetes config")
+		return
 	}
 
 	splitClient, err := smiSplitClient.NewForConfig(kubeConfig)

--- a/pkg/osm/version/types_test.go
+++ b/pkg/osm/version/types_test.go
@@ -15,7 +15,7 @@ func TestEnvoyConfigParser(t *testing.T) {
 	assert := tassert.New(t)
 	actual := getReleases()
 
-	assert.Equal([]string{"v0.10", "v0.11", "v0.6", "v0.7", "v0.8", "v0.9"}, actual)
+	assert.Equal([]string{"v0.10", "v0.11", "v0.7", "v0.8", "v0.9"}, actual)
 
 	for _, release := range actual {
 		controllerVersion := ControllerVersion(release)


### PR DESCRIPTION
Certain errors in connectivity pod-to-pod checks prevent
further meaningful checks in pod connectivity from being
run. The following failures are irrecoverable roadblocks
preventing the checks from being run, so osm-health should
terminate upon encountering any of these.
(1) failure to initialize the k8s client,
(2) failure to obtain the kubeconfig, or
(3) failure to obtain osm info (possibly due to incorrect
mesh namespace specified)

Resolves #107.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>