### PR TITLE
Fix panic when there is an endpoint address with no targetRef

### DIFF
--- a/pkg/kubernetes/podhelper/endpoints.go
+++ b/pkg/kubernetes/podhelper/endpoints.go
@@ -42,7 +42,7 @@ func (e EndpointsCheck) Run() outcomes.Outcome {
 	for _, ep := range eps.Items {
 		for _, subset := range ep.Subsets {
 			for _, addr := range subset.Addresses {
-				if addr.TargetRef.Name == e.pod.Name {
+				if addr.TargetRef != nil && addr.TargetRef.Name == e.pod.Name {
 					found = true
 					break
 				}

--- a/pkg/kubernetes/podhelper/endpoints_test.go
+++ b/pkg/kubernetes/podhelper/endpoints_test.go
@@ -202,6 +202,33 @@ func TestEndpointsCheck(t *testing.T) {
 			},
 			pass: true,
 		},
+		{
+			name: "ok when there is no targetRef",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+				},
+			},
+			endpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "a-unique-name",
+						Namespace: "b",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									TargetRef: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			pass: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
If there is an endpoint in a namespace that includes a tested pod (e.g. `osm-health connectivity pod-to-pod default/pod1 default/pod2`) that has an address with no targetRef then it panics with a segmentation violation:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1ab749e]

goroutine 1 [running]:
github.com/openservicemesh/osm-health/pkg/kubernetes/podhelper.EndpointsCheck.Run(0x2691d48, 0xc000ded8c0, 0xc000614c00, 0xc000d83500, 0xd)
        /home/trstringer/dev/osm-health/pkg/kubernetes/podhelper/endpoints.go:45 +0x15e
github.com/openservicemesh/osm-health/pkg/runner.Run(0xc00062ba90, 0x27, 0x27, 0xc000440000, 0xc000614400, 0x235dd80)
        /home/trstringer/dev/osm-health/pkg/runner/runner.go:12 +0xb1
github.com/openservicemesh/osm-health/pkg/connectivity.PodToPod(0xc000614400, 0xc000614c00, 0x7ffedc123211, 0xb)
        /home/trstringer/dev/osm-health/pkg/connectivity/pod-to-pod.go:145 +0x1ab9
main.newConnectivityPodToPodCmd.func1(0xc00089b180, 0xc0009c3900, 0x2, 0x4, 0x0, 0x0)
        /home/trstringer/dev/osm-health/cmd/connectivity_pod_to_pod.go:44 +0x1b9
github.com/spf13/cobra.(*Command).execute(0xc00089b180, 0xc0009c38c0, 0x4, 0x4, 0xc00089b180, 0xc0009c38c0)
        /home/trstringer/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc00089aa00, 0x2381081, 0x1e, 0xc00091ff48)
        /home/trstringer/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /home/trstringer/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
main.main()
        /home/trstringer/dev/osm-health/cmd/main.go:67 +0x13a
```

The endpoint subsets could look like this:

```yaml
subsets:
- addresses:
  - ip: 1.2.3.4
  ports:
  - name: https
    port: 443
    protocol: TCP
```

In this case, `subsets[0].addresses[0].targetRef` is nil.

I have added a failing test that exposes this issue as well.