### PR TITLE
Add tcp_proxy for envoy config

### DIFF
--- a/pkg/envoy/parse.go
+++ b/pkg/envoy/parse.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 
 	"google.golang.org/protobuf/encoding/protojson"


### PR DESCRIPTION
This PR fixes the following error:

```
ERR Error parsing JSON bytes error="proto:\u00a0(line 1627:21): unable to resolve \"type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy\": \"not found\"" file=parse.go:29 module=envoy
```