### PR TITLE
remove todos

### DIFF
--- a/cmd/connectivity_pod_to_pod.go
+++ b/cmd/connectivity_pod_to_pod.go
@@ -12,10 +12,7 @@ const connectivityPodToPodDesc = `
 Checks connectivity between two Kubernetes pods
 `
 
-const connectivityPodToPodExample = `
-Example:
-	$ osm-health connectivity pod-to-pod namespace-a/pod-a namespace-b/pod-b
-`
+const connectivityPodToPodExample = `$ osm-health connectivity pod-to-pod namespace-a/pod-a namespace-b/pod-b`
 
 func newConnectivityPodToPodCmd() *cobra.Command {
 	return &cobra.Command{

--- a/cmd/connectivity_pod_to_url.go
+++ b/cmd/connectivity_pod_to_url.go
@@ -14,10 +14,7 @@ const connectivityPodToURLDesc = `
 Checks connectivity between a Kubernetes pod and a host name (or URL)
 `
 
-const connectivityPodToURLExample = `
-Example:
-	$ osm-health connectivity pod-to-url namespace-a/pod-a https://contoso.com/store
-`
+const connectivityPodToURLExample = `$ osm-health connectivity pod-to-url namespace-a/pod-a https://contoso.com/store`
 
 func newConnectivityPodToURLCmd() *cobra.Command {
 	return &cobra.Command{

--- a/cmd/control_plane_status.go
+++ b/cmd/control_plane_status.go
@@ -8,12 +8,14 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
+const controlPlaneStatusExample = `$ osm-health ingress to-pod namespace-a/pod-a`
+
 func newControlPlaneStatusCmd(actionConfig *action.Configuration) *cobra.Command {
 	var localPort uint16
 	cmd := &cobra.Command{
 		Use:     "status",
 		Short:   "Checks the status of the osm control plane",
-		Example: `TODO add example`,
+		Example: controlPlaneStatusExample,
 		Long:    `Checks the status of the osm control plane`,
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cmd/ingress_to_pod.go
+++ b/cmd/ingress_to_pod.go
@@ -8,12 +8,15 @@ import (
 	"github.com/openservicemesh/osm-health/pkg/kubernetes/pod"
 )
 
+const ingressToPodExample = `$ osm-health ingress to-pod namespace-a/pod-a`
+
 func newIngressToPodCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "to-pod DESTINATION_POD",
-		Short: "Checks ingress to a given Kubernetes pod",
-		Long:  `Checks ingress to a given Kubernetes pod`,
-		Args:  cobra.ExactArgs(1),
+		Use:     "to-pod DESTINATION_POD",
+		Short:   "Checks ingress to a given Kubernetes pod",
+		Example: ingressToPodExample,
+		Long:    `Checks ingress to a given Kubernetes pod`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.Errorf("missing DESTINATION_POD parameter")
@@ -30,11 +33,12 @@ func newIngressToPodCmd() *cobra.Command {
 				return errors.New("invalid DESTINATION_POD")
 			}
 
-			ingress.ToDestinationPod(client, dstPod)
+			osmControlPlaneNamespace := settings.Namespace()
+
+			ingress.ToDestinationPod(client, dstPod, osmControlPlaneNamespace)
 
 			return nil
 		},
-		Example: `TODO`,
 	}
 	return cmd
 }

--- a/pkg/ingress/pod.go
+++ b/pkg/ingress/pod.go
@@ -6,21 +6,24 @@ import (
 
 	"github.com/openservicemesh/osm-health/pkg/common"
 	"github.com/openservicemesh/osm-health/pkg/kubernetes/namespace"
+	"github.com/openservicemesh/osm-health/pkg/osm/utils"
 	"github.com/openservicemesh/osm-health/pkg/printer"
 	"github.com/openservicemesh/osm-health/pkg/runner"
 )
 
 // ToDestinationPod checks the Ingress to the given pod.
-func ToDestinationPod(client kubernetes.Interface, dstPod *corev1.Pod) {
+func ToDestinationPod(client kubernetes.Interface, dstPod *corev1.Pod, osmControlPlaneNamespace common.MeshNamespace) {
 	log.Info().Msgf("Testing ingress to pod %s/%s", dstPod.Namespace, dstPod.Name)
 
-	// TODO
-	meshName := common.MeshName("osm")
+	meshInfo, err := utils.GetMeshInfo(client, osmControlPlaneNamespace)
+	if err != nil {
+		log.Err(err).Msg("Error getting OSM info")
+	}
 
 	outcomes := runner.Run(
 		// Check destination Pod's namespace
 		namespace.NewSidecarInjectionCheck(client, dstPod.Namespace),
-		namespace.NewMonitoredCheck(client, dstPod.Namespace, meshName),
+		namespace.NewMonitoredCheck(client, dstPod.Namespace, meshInfo.Name),
 	)
 
 	printer.Print(outcomes...)

--- a/pkg/kubernetes/namespace/monitored.go
+++ b/pkg/kubernetes/namespace/monitored.go
@@ -32,7 +32,7 @@ func NewMonitoredCheck(client kubernetes.Interface, namespace string, meshName c
 
 // Description implements common.Runnable
 func (check MonitoredCheck) Description() string {
-	return fmt.Sprintf("Checking whether namespace %s is monitored by OSM %s", check.namespace, check.meshName)
+	return fmt.Sprintf("Checking whether namespace %s is monitored by mesh %s", check.namespace, check.meshName)
 }
 
 // Run implements common.Runnable


### PR DESCRIPTION
* Adds missing command examples
* Updates all command examples to follow a consistent format
* Uses mesh-name detection from env for ingress checks (this was previously hardcoded as "osm")