### PR TITLE
feat(cli): show error messages for wrong arg count

### DIFF
--- a/cmd/connectivity_pod_to_pod.go
+++ b/cmd/connectivity_pod_to_pod.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/openservicemesh/osm-health/pkg/cli"
 	"github.com/openservicemesh/osm-health/pkg/connectivity"
 	"github.com/openservicemesh/osm-health/pkg/kubernetes/pod"
 )
@@ -12,28 +13,24 @@ const connectivityPodToPodDesc = `
 Checks connectivity between two Kubernetes pods
 `
 
-const connectivityPodToPodExample = `$ osm-health connectivity pod-to-pod namespace-a/pod-a namespace-b/pod-b`
+const connectivityPodToPodExample = `$ osm-health connectivity pod-to-pod source-namespace/source-pod destination-namespace/destination-pod`
 
 func newConnectivityPodToPodCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "pod-to-pod SOURCE_POD DESTINATION_POD",
+		Use:     "pod-to-pod source-namespace/source-pod destination-namespace/destination-pod",
 		Short:   "Checks connectivity between Kubernetes pods",
 		Example: connectivityPodToPodExample,
 		Long:    connectivityPodToPodDesc,
-		Args:    cobra.ExactArgs(2),
+		Args:    cli.ExactArgsWithError(2, errors.New("requires 2 arguments: source-namespace/source-pod destination-namespace/destination-pod")),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) < 2 {
-				return errors.Errorf("provide both SOURCE_POD and DESTINATION_POD")
-			}
-
 			srcPod, err := pod.FromString(args[0])
 			if err != nil {
-				return errors.New("invalid SOURCE_POD")
+				return errors.New("invalid source-namespace/source-pod")
 			}
 
 			dstPod, err := pod.FromString(args[1])
 			if err != nil {
-				return errors.New("invalid DESTINATION_POD")
+				return errors.New("invalid destination-namespace/destination-pod")
 			}
 
 			osmControlPlaneNamespace := settings.Namespace()

--- a/cmd/connectivity_pod_to_url.go
+++ b/cmd/connectivity_pod_to_url.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/openservicemesh/osm-health/pkg/cli"
 	"github.com/openservicemesh/osm-health/pkg/connectivity"
 	"github.com/openservicemesh/osm-health/pkg/kubernetes/pod"
 )
@@ -14,28 +15,24 @@ const connectivityPodToURLDesc = `
 Checks connectivity between a Kubernetes pod and a host name (or URL)
 `
 
-const connectivityPodToURLExample = `$ osm-health connectivity pod-to-url namespace-a/pod-a https://contoso.com/store`
+const connectivityPodToURLExample = `$ osm-health connectivity pod-to-url source-namespace/source-pod https://contoso.com/store`
 
 func newConnectivityPodToURLCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "pod-to-url SOURCE_POD DESTINATION_URL",
+		Use:     "pod-to-url source-namespace/source-pod destination-url",
 		Short:   "Checks connectivity between a Kubernetes pod and a given URL",
 		Example: connectivityPodToURLExample,
 		Long:    connectivityPodToURLDesc,
-		Args:    cobra.ExactArgs(2),
+		Args:    cli.ExactArgsWithError(2, errors.New("requires 2 arguments: source-namespace/source-pod destination-url")),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) < 2 {
-				return errors.Errorf("provide both SOURCE_POD and DESTINATION_URL")
-			}
-
 			srcPod, err := pod.FromString(args[0])
 			if err != nil {
-				return errors.New("invalid SOURCE_POD")
+				return errors.New("invalid source-namespace/source-pod")
 			}
 
 			dstURL, err := url.Parse(args[1])
 			if err != nil {
-				return errors.New("invalid DESTINATION_URL")
+				return errors.New("invalid destination-url")
 			}
 
 			connectivity.PodToURL(srcPod, dstURL, settings.Namespace())

--- a/cmd/ingress_to_pod.go
+++ b/cmd/ingress_to_pod.go
@@ -4,23 +4,21 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/openservicemesh/osm-health/pkg/cli"
 	"github.com/openservicemesh/osm-health/pkg/ingress"
 	"github.com/openservicemesh/osm-health/pkg/kubernetes/pod"
 )
 
-const ingressToPodExample = `$ osm-health ingress to-pod namespace-a/pod-a`
+const ingressToPodExample = `$ osm-health ingress to-pod destination-namespace/destination-pod`
 
 func newIngressToPodCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "to-pod DESTINATION_POD",
+		Use:     "to-pod destination-namespace/destination-pod",
 		Short:   "Checks ingress to a given Kubernetes pod",
 		Example: ingressToPodExample,
 		Long:    `Checks ingress to a given Kubernetes pod`,
-		Args:    cobra.ExactArgs(1),
+		Args:    cli.ExactArgsWithError(1, errors.New("requires 1 argument: destination-namespace/destination-pod")),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) < 1 {
-				return errors.Errorf("missing DESTINATION_POD parameter")
-			}
 			log.Info().Msgf("Checking Ingress to Pod %s", args[0])
 
 			client, err := pod.GetKubeClient()
@@ -30,7 +28,7 @@ func newIngressToPodCmd() *cobra.Command {
 
 			dstPod, err := pod.FromString(args[0])
 			if err != nil {
-				return errors.New("invalid DESTINATION_POD")
+				return errors.New("invalid destination-namespace/destination-pod")
 			}
 
 			osmControlPlaneNamespace := settings.Namespace()

--- a/pkg/cli/args.go
+++ b/pkg/cli/args.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// ExactArgsWithError returns the error if there are not exactly n args.
+func ExactArgsWithError(n int, e error) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != n {
+			return e
+		}
+		return nil
+	}
+}

--- a/pkg/cli/args_test.go
+++ b/pkg/cli/args_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestExactArgsWithError(t *testing.T) {
+	tests := []struct {
+		name          string
+		nArgs         int
+		args          []string
+		expectedError error
+	}{
+		{
+			name:          "exact args without error",
+			nArgs:         2,
+			args:          []string{"foo", "bar"},
+			expectedError: nil,
+		},
+		{
+			name:          "too few args",
+			nArgs:         2,
+			args:          []string{"foo"},
+			expectedError: errors.New("expected 2 args, got 1"),
+		},
+		{
+			name:          "too many args",
+			nArgs:         2,
+			args:          []string{"foo", "bar", "baz"},
+			expectedError: errors.New("expected 2 args, got 3"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			cobraArg := ExactArgsWithError(test.nArgs, test.expectedError)
+			err := cobraArg(&cobra.Command{}, test.args)
+
+			if test.expectedError != nil {
+				assert.EqualError(err, test.expectedError.Error())
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}

--- a/pkg/osm/version/types_test.go
+++ b/pkg/osm/version/types_test.go
@@ -15,7 +15,7 @@ func TestEnvoyConfigParser(t *testing.T) {
 	assert := tassert.New(t)
 	actual := getReleases()
 
-	assert.Equal([]string{"v0.10", "v0.11", "v0.6", "v0.7", "v0.8", "v0.9"}, actual)
+	assert.Equal([]string{"v0.10", "v0.11", "v0.7", "v0.8", "v0.9"}, actual)
 
 	for _, release := range actual {
 		controllerVersion := ControllerVersion(release)


### PR DESCRIPTION
Shows meaningful, verbose, and friendly error messages when
incorrect number of args are presented to the command.

Resolves #116.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>